### PR TITLE
install.md: update Julia 1.1.0 -> 1.3.1

### DIFF
--- a/install.md
+++ b/install.md
@@ -61,8 +61,8 @@ apt-get install 4ti2 ant ant-optional autoconf autogen bliss build-essential bzi
 Now install Julia:
 
 {% highlight bash %}
-wget https://julialang-s3.julialang.org/bin/linux/x64/1.1/julia-1.1.0-linux-x86_64.tar.gz
-tar xf julia-1.1.0-linux-x86_64.tar.gz
+wget https://julialang-s3.julialang.org/bin/linux/x64/1.3/julia-1.3.1-linux-x86_64.tar.gz
+tar xf julia-1.3.1-linux-x86_64.tar.gz
 {% endhighlight %}
 
 Now start Julia


### PR DESCRIPTION
Caveat: I am not sure this actually is OK, i.e., if everything works with Julia 1.3.1. I know that GAP.jl does, and I think I managed to install all other OSCAR packages, but admittedly I didn't test them all thoroughly... 

If there are known issues, we could switch to Julia 1.2.0 or at least 1.1.1 instead.