### PR TITLE
Fix a bunch of links and URLs

### DIFF
--- a/README.hyde.md
+++ b/README.hyde.md
@@ -1,6 +1,6 @@
 # Hyde
 
-Hyde is a brazen two-column [Jekyll](http://jekyllrb.com) theme that pairs a prominent sidebar with uncomplicated content. It's based on [Poole](http://getpoole.com), the Jekyll butler.
+Hyde is a brazen two-column [Jekyll](https://jekyllrb.com) theme that pairs a prominent sidebar with uncomplicated content. It's based on [Poole](https://getpoole.com), the Jekyll butler.
 
 ![Hyde screenshot](https://f.cloud.github.com/assets/98681/1831228/42af6c6a-7384-11e3-98fb-e0b923ee0468.png)
 
@@ -30,7 +30,7 @@ Hyde includes some customizable options, typically applied via classes on the `<
 
 ### Sidebar menu
 
-Create a list of nav links in the sidebar by assigning each Jekyll page the correct layout in the page's [front-matter](http://jekyllrb.com/docs/frontmatter/).
+Create a list of nav links in the sidebar by assigning each Jekyll page the correct layout in the page's [front-matter](https://jekyllrb.com/docs/frontmatter/).
 
 ```
 ---

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Please add a new entry to the `_data/contributors.yml` file, of the following fo
 - name: Sebastian Gutsche
   affiliation: University of Siegen
   email: gutsche@mathematik.uni-siegen.de
-  website: http://sebasguts.github.io
+  website: https://sebasguts.github.io
 ```
 All three entries, `affiliation`, `email`, and `website` are optional. If you provide an `email` and a `website`, the name will link to the website.
 
@@ -125,7 +125,7 @@ All three entries, `affiliation`, `email`, and `website` are optional. If you pr
 Please add a new entry to the `_data/used_software.yml` file, of the following form:
 ```
 - name: GAP
-  website: http://www.gap-system.org
+  website: https://www.gap-system.org
 ```
 
 ## How to add a new meeting subpage

--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ title:            'OSCAR Computer Algebra System'
 tagline:          ''
 description:      'The OSCAR project'
 location:         ''
-url:              http://sebasguts.github.io
+url:              http://oscar.github.io
 baseurl:          /oscar-website/
 
 

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -4,7 +4,7 @@
 
 - name: Reimer Behrends
   affiliation: TU Kaiserslautern
-  website: http://www.mathematik.uni-kl.de/agag/mitglieder/wissenschaftliche-mitarbeiter/dr-reimer-behrends/
+  #website: https://www.mathematik.uni-kl.de/agag/mitglieder/wissenschaftliche-mitarbeiter/dr-reimer-behrends/
   paid_by_dfg: true
 
 - name: Alex Best
@@ -19,11 +19,11 @@
 
 - name: Wolfram Decker
   affiliation: TU Kaiserslautern
-  website: http://www.mathematik.uni-kl.de/en/agag/members/professors/prof-dr-wolfram-decker/
+  website: https://www.mathematik.uni-kl.de/en/agag/people/head/prof-dr-wolfram-decker/
 
 - name: Christian Eder
   affiliation: TU Kaiserslautern
-  website: http://www.mathematik.uni-kl.de/~ederc/index.html
+  website: https://www.mathematik.uni-kl.de/~ederc/index.html
 
 - name: Raul Epure
   affiliation: TU Kaiserslautern
@@ -31,7 +31,7 @@
   
 - name: Claus Fieker
   affiliation: TU Kaiserslautern
-  website: http://www.mathematik.uni-kl.de/agag/mitglieder/professoren/prof-dr-claus-fieker/
+  website: https://www.mathematik.uni-kl.de/en/agag/people/head/prof-dr-claus-fieker/
 
 - name: Sebastian Gutsche
   affiliation: University of Siegen
@@ -41,7 +41,7 @@
 
 - name: William Hart
   affiliation: TU Kaiserslautern
-  website: http://www.mathematik.uni-kl.de/agag/mitglieder/wissenschaftliche-mitarbeiter/dr-william-hart/
+  #website: https://www.mathematik.uni-kl.de/agag/mitglieder/wissenschaftliche-mitarbeiter/dr-william-hart/
   paid_by_dfg: true
 
 - name: Florian Heiderich
@@ -50,7 +50,7 @@
   
 - name: Tommy Hofmann
   affiliation: TU Kaiserslautern
-  website: http://www.mathematik.uni-kl.de/agag/mitglieder/wissenschaftliche-mitarbeiter/thofmann/
+  website: https://www.mathematik.uni-kl.de/~thofmann/
 
 - name: Max Horn
   affiliation: University of Siegen
@@ -62,7 +62,7 @@
 
 - name: Michael Joswig
   affiliation: TU Berlin
-  website: http://page.math.tu-berlin.de/~joswig/
+  website: https://page.math.tu-berlin.de/~joswig/
 
 - name: Marek Kaluba
   affiliation: Adam Mickiewicz University, Poznań
@@ -70,7 +70,7 @@
 
 - name: Lars Kastner
   affiliation: TU Berlin
-  website: http://page.math.tu-berlin.de/~kastner/
+  website: https://page.math.tu-berlin.de/~kastner/
 
 - name: Benjamin Lorenz
   affiliation: TU Berlin
@@ -108,15 +108,15 @@
   
 - name: Hans Schönemann
   affiliation: TU Kaiserslautern
-  website: http://www.mathematik.uni-kl.de/agag/mitglieder/wissenschaftliche-mitarbeiter/dr-hans-schoenemann/
+  #website: https://www.mathematik.uni-kl.de/agag/mitglieder/wissenschaftliche-mitarbeiter/dr-hans-schoenemann/
 
 - name: Carlo Sircana
   affiliation: TU Kaiserslautern
-  website: http://www.mathematik.uni-kl.de/agag/mitglieder/wissenschaftliche-mitarbeiter/carlo-sircana/
+  #website: https://www.mathematik.uni-kl.de/agag/mitglieder/wissenschaftliche-mitarbeiter/carlo-sircana/
 
 - name: Andreas Steenpaß
   affiliation: TU Kaiserslautern
-  website: http://www.mathematik.uni-kl.de/agag/mitglieder/wissenschaftliche-mitarbeiter/dr-andreas-steenpass/
+  #website: https://www.mathematik.uni-kl.de/agag/mitglieder/wissenschaftliche-mitarbeiter/dr-andreas-steenpass/
   
 - name: Sascha Timme
   affiliation: TU Berlin

--- a/_data/used_software.yml
+++ b/_data/used_software.yml
@@ -1,5 +1,5 @@
 - name: GAP
-  website: http://www.gap-system.org
+  website: https://www.gap-system.org
 
 - name: Nemo
   website: http://www.nemocas.org
@@ -8,25 +8,25 @@
   website: https://github.com/thofma/Hecke.jl/
 
 - name: Polymake
-  website: http://www.polymake.org/
+  website: https://www.polymake.org/
 
 - name: Singular
   website: http://www.singular.uni-kl.de/
 
 - name: GMP
-  website: http://gmplib.org/
+  website: https://gmplib.org/
 
 - name: MPIR
   website: http://mpir.org/
 
 - name: MPFR
-  website: http://mpfr.org/
+  website: https://www.mpfr.org/
 
 - name: Arb
   website: http://arblib.org/
 
 - name: NTL
-  website: http://www.shoup.net/ntl
+  website: https://www.shoup.net/ntl
 
 - name: Flint
   website: http://www.flintlib.org

--- a/feed-blog.xml
+++ b/feed-blog.xml
@@ -2,12 +2,12 @@
 layout: none
 ---
 <?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
+<feed xmlns="https://www.w3.org/2005/Atom">
   <author>
     <name>The OSCAR Team</name>
   </author>
   <title>OSCAR blog</title>
-  <id>http://oscar.computeralgebra.de</id>
+  <id>https://oscar.computeralgebra.de</id>
   <updated>{{ site.time }}</updated>
 
 {% for post in site.categories.blogs %}

--- a/feed-examples.xml
+++ b/feed-examples.xml
@@ -2,12 +2,12 @@
 layout: none
 ---
 <?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
+<feed xmlns="https://www.w3.org/2005/Atom">
   <author>
     <name>The OSCAR Team</name>
   </author>
   <title>OSCAR examples</title>
-  <id>http://oscar.computeralgebra.de</id>
+  <id>https://oscar.computeralgebra.de</id>
   <updated>{{ site.time }}</updated>
 
 {% for post in site.categories.examples %}

--- a/feed-news.xml
+++ b/feed-news.xml
@@ -2,12 +2,12 @@
 layout: none
 ---
 <?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
+<feed xmlns="https://www.w3.org/2005/Atom">
   <author>
     <name>The OSCAR Team</name>
   </author>
   <title>OSCAR news</title>
-  <id>http://oscar.computeralgebra.de</id>
+  <id>https://oscar.computeralgebra.de</id>
   <updated>{{ site.time }}</updated>
 
 {% for post in site.categories.news %}


### PR DESCRIPTION
There were lots of 404 errors for the homepages of project members; seems TU Kaiserslautern shuffles URLs randomly every couple months? I fixed the links to @fieker and @wdecker but could not find any homepages for @wbhart @thofma @rbehrends @CarloSircana @hannes14 so I just disabled those for now.  We could instead point at their GitHub pages, or the TU Kaiserslautern could resume providing homepages for all researchers they employ *shrug*, that's not something I can influence (yet!).

Also, I think Andreas Steenpaß isn't at the TU Kaiserslautern anymore; perhaps we should point that out?

Besides that, I changed a bunch of URLs from http to https (unfortunately, this is not supported by the homepages of Arb, Flint, Nemo, and a few others).

Finally, I fixed the homepage URL in the `_config.yml`, it was still pointing at @sebasguts homepage (shouldn't really matter for deployment, though).