### PR TITLE
add horizontal scrolling for code when it's too wide

### DIFF
--- a/public/css/poole.css
+++ b/public/css/poole.css
@@ -186,6 +186,10 @@ pre code {
 }
 .highlight pre {
   margin-bottom: 0;
+
+  /* add scrolling for code blocks which are too wide */
+  white-space: pre;
+  overflow: auto;
 }
 
 /* Gist via GitHub Pages */


### PR DESCRIPTION
The alternative consisting in letting long lines overflow their "parent" (I don't know the official word) is too ugly (achieved by removing `overflow: auto` from this PR):
![scroll](https://user-images.githubusercontent.com/8462914/80571415-e251d880-89fc-11ea-84c8-a7d27ff13fba.png)

And I didn't find how to automatically widen said "parent" to a big enough width to accomodate the width of code (and then, what to do when this would span wider than the screen itself?).

Fix #97.
As usual, preview at https://rfourquet.github.io/oscar-website/install/