### PR TITLE
remove CxxWrap workaround on MacOS

### DIFF
--- a/install.md
+++ b/install.md
@@ -95,32 +95,6 @@ now?</q>. Confirm this by clicking <q>Install</q>.</li>
 contains executables such as <code>clang</code> and <code>clang++</code>,
 the C and C++ compiler.</li>
 </ol>
-<p>
-Note: some users have experienced build failures on macOS 10.15 with Xcode 11.4
-(cf. this <a href="https://github.com/oscar-system/Oscar.jl/issues/82">github issue</a>).
-Until a proper fix is found, the following might serve as a workaround, consisting in building <code>libcxxwrap-julia</code>
-with Xcode 11.4 instead of using the binaries (replace <code>$SOMEWHERE</code> by
-the directory in which you wish to install <code>libcxxwrap-julia</code>,
-for example <code>$HOME/.julia/cxxwrap-workaround/</code>):
-{% highlight bash %}
-git clone -b v0.7.0 --depth 1 https://github.com/JuliaInterop/libcxxwrap-julia
-cd libcxxwrap-julia
-mkdir build
-cd build
-cmake -DCMAKE_INSTALL_PREFIX=$SOMEWHERE/libcxxwrap-julia-install -DCMAKE_BUILD_TYPE=Release ..
-VERBOSE=ON cmake --build . --config Release --target install
-{% endhighlight %}
-Then, set up an "override file" (as indicated
-<a href="https://github.com/JuliaInterop/libcxxwrap-julia#using-the-compiled-libcxxwrap-julia-in-cxxwrap">here</a>),
-which is, by default, located at <code>~/.julia/artifacts/Overrides.toml</code>.
-Create this file if it doesn't already exist, and add to it the following content:
-{% highlight toml %}
-[3eaa8342-bff7-56a5-9981-c04077f7cee7]
-libcxxwrap_julia = "$SOMEWHERE/libcxxwrap-julia-install"
-{% endhighlight %}
-Finally, rebuild <code>Oscar</code> by typing the following in your Julia REPL:
-<code>using Pkg; Pkg.build("Oscar")</code>.
-</p>
 </details>
 
 <details>


### PR DESCRIPTION
The problem is now fixed in Polymake.jl and Singular.jl, 
cf. https://github.com/oscar-system/Oscar.jl/issues/82#issuecomment-621941752