### PR TITLE
split Credits and Contributors

### DIFF
--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -39,7 +39,7 @@
   affiliation: TU Kaiserslautern
 
 - name: Sebastian Gutsche
-  affiliation: University of Siegen
+  affiliation: Amazon
   email: gutsche@mathematik.uni-siegen.de
   website: https://sebasguts.github.io/
   paid_by_dfg: true
@@ -67,13 +67,16 @@
   affiliation: Institut de Mathématiques de Bordeaux
   website: http://fredrikj.net/
 
+- name: Alexej Jordan
+  affiliation: TU Berlin
+
 - name: Michael Joswig
   affiliation: TU Berlin
   website: https://page.math.tu-berlin.de/~joswig/
   is_active_PI: true
 
 - name: Marek Kaluba
-  affiliation: Adam Mickiewicz University, Poznań
+  affiliation: Adam Mickiewicz University, Poznań and TU Berlin
   website: https://kalmar.faculty.wmi.amu.edu.pl/
 
 - name: Lars Kastner

--- a/_data/contributors.yml
+++ b/_data/contributors.yml
@@ -10,7 +10,7 @@
 - name: Alex Best
   affiliation: Boston University
   website: https://github.com/alexjbest
-  
+
 - name: Thomas Breuer
   affiliation: RWTH Aachen University
   email: thomas.breuer@math.rwth-aachen.de
@@ -20,6 +20,7 @@
 - name: Wolfram Decker
   affiliation: TU Kaiserslautern
   website: https://www.mathematik.uni-kl.de/en/agag/people/head/prof-dr-wolfram-decker/
+  is_active_PI: true
 
 - name: Christian Eder
   affiliation: TU Kaiserslautern
@@ -28,10 +29,11 @@
 - name: Raul Epure
   affiliation: TU Kaiserslautern
   website: https://github.com/raulepure
-  
+
 - name: Claus Fieker
   affiliation: TU Kaiserslautern
   website: https://www.mathematik.uni-kl.de/en/agag/people/head/prof-dr-claus-fieker/
+  is_active_PI: true
 
 - name: Rafael Fourquet
   affiliation: TU Kaiserslautern
@@ -59,6 +61,7 @@
 - name: Max Horn
   affiliation: TU Kaiserslautern
   website: https://www.quendi.de/math
+  is_active_PI: true
 
 - name: Fredrik Johansson
   affiliation: Institut de Mathématiques de Bordeaux
@@ -67,6 +70,7 @@
 - name: Michael Joswig
   affiliation: TU Berlin
   website: https://page.math.tu-berlin.de/~joswig/
+  is_active_PI: true
 
 - name: Marek Kaluba
   affiliation: Adam Mickiewicz University, Poznań
@@ -87,10 +91,10 @@
 - name: Frank Lübeck
   affiliation: RWTH Aachen University
   website: http://www.math.rwth-aachen.de/~Frank.Luebeck/index.html
-  
+
 - name: Alexander Mattes
   website: https://github.com/alexandermattes
-  
+
 - name: Sachin Mohan
   affiliation: TU Kaiserslautern
   website: https://github.com/sachinkm308
@@ -98,10 +102,10 @@
 - name: Oleksandr Motsak
   affiliation: IMAGINARY
   website: https://imaginary.org/users/oleksandr-motsak
-  
+
 - name: Markus Pfeiffer
   website: https://github.com/markuspf
-  
+
 - name: Sebastian Posur
   affiliation: University of Siegen
   website: https://sebastianpos.github.io/
@@ -113,7 +117,7 @@
 - name: Johannes Schmitt
   affiliation: TU Kaiserslautern
   website: https://github.com/joschmitt
-  
+
 - name: Hans Schönemann
   affiliation: TU Kaiserslautern
   #website: https://www.mathematik.uni-kl.de/agag/mitglieder/wissenschaftliche-mitarbeiter/dr-hans-schoenemann/
@@ -125,11 +129,11 @@
 - name: Andreas Steenpaß
   affiliation: TU Kaiserslautern
   #website: https://www.mathematik.uni-kl.de/agag/mitglieder/wissenschaftliche-mitarbeiter/dr-andreas-steenpass/
-  
+
 - name: Sascha Timme
   affiliation: TU Berlin
   website: https://github.com/saschatimme
-  
+
 - name: Erec Thorn
   affiliation: TU Kaiserslautern
   website: https://github.com/erecthorn

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -56,6 +56,8 @@
 
       <a class="sidebar-nav-item{% if page.url == '/credits/' %} active{% endif %}" href="{{ site.baseurl }}/credits">Credits</a>
 
+      <a class="sidebar-nav-item{% if page.url == '/contributors/' %} active{% endif %}" href="{{ site.baseurl }}/contributors">Contributors</a>
+
       <!-- {% comment %}
         The code below dynamically generates a sidebar nav of pages with
         `layout: page` in the front-matter. See readme for usage.

--- a/contributors.md
+++ b/contributors.md
@@ -1,0 +1,47 @@
+---
+layout: page
+title: Contributors
+---
+
+Currently, the following people contributed very significantly to the software in the
+OSCAR project:
+
+{% assign entries = site.data.contributors | sort_natural:"name" %}
+<ul>
+{% for p in site.data.contributors %}
+  <li>
+    {% if p.website != null %}
+        <a href="{{ p.website }}">
+        {% assign link_open = true %}
+    {% elsif p.email != null %}
+        <a href="mailto:{{ p.email }}">
+        {% assign link_open = true %}
+    {% endif %}
+    <strong>{{ p.name }}</strong>{% if link_open %}</a>{% assign link_open = false %}{% endif %}
+    {% if p.affiliation != null %} ({{ p.affiliation }}){% endif %}
+  </li>
+{% endfor %}
+</ul>
+
+## Contributors financed by the DFG SFB-TRR 195 (2017 - 2020)
+
+Additionally, the following people were or are financed by the [SFB-TRR 195](https://www.computeralgebra.de/sfb/) to mainly work on software
+for the OSCAR project:
+
+<ul>
+{% for p in site.data.contributors %}
+{% if p.paid_by_dfg == true %}
+  <li>
+    {% if p.website != null %}
+        <a href="{{ p.website }}">
+        {% assign link_open = true %}
+    {% elsif p.email != null %}
+        <a href="mailto:{{ p.email }}">
+        {% assign link_open = true %}
+    {% endif %}
+    <strong>{{ p.name }}</strong>{% if link_open %}</a>{% assign link_open = false %}{% endif %}
+    {% if p.affiliation != null %} ({{ p.affiliation }}){% endif %}
+  </li>
+{% endif %}
+{% endfor %}
+</ul>

--- a/contributors.md
+++ b/contributors.md
@@ -3,7 +3,7 @@ layout: page
 title: Contributors
 ---
 
-## Active PIs
+## Project leaders
 
 <ul>
 {% for p in site.data.contributors %}

--- a/contributors.md
+++ b/contributors.md
@@ -44,15 +44,15 @@ for the OSCAR project.
     <strong>{{ p.name }}</strong>{% if link_open %}</a>{% assign link_open = false %}{% endif %}
     {% if p.affiliation != null or p.paid_by_dfg == true %}
         (
-        {% if p.affiliation != null %}
+        {%- if p.affiliation != null -%}
             {{ p.affiliation }}
-        {% endif %}
-        {% if p.paid_by_dfg == true %}
-            {% if p.affiliation != null %}
+        {%- endif -%}
+        {%- if p.paid_by_dfg == true -%}
+            {%- if p.affiliation != null -%}
             ,
             {% endif %}
             financed by the <a href="https://www.computeralgebra.de/sfb/">SFB-TRR 195</a>
-        {% endif %}
+        {%- endif -%}
         )
     {% endif %}
 

--- a/contributors.md
+++ b/contributors.md
@@ -3,6 +3,28 @@ layout: page
 title: Contributors
 ---
 
+## Active PIs
+
+<ul>
+{% for p in site.data.contributors %}
+{% if p.is_active_PI == true %}
+  <li>
+    {% if p.website != null %}
+        <a href="{{ p.website }}">
+        {% assign link_open = true %}
+    {% elsif p.email != null %}
+        <a href="mailto:{{ p.email }}">
+        {% assign link_open = true %}
+    {% endif %}
+    <strong>{{ p.name }}</strong>{% if link_open %}</a>{% assign link_open = false %}{% endif %}
+    {% if p.affiliation != null %} ({{ p.affiliation }}){% endif %}
+  </li>
+{% endif %}
+{% endfor %}
+</ul>
+
+## Contributors
+
 Currently, the following people contributed very significantly to the software in the
 OSCAR project:
 

--- a/contributors.md
+++ b/contributors.md
@@ -26,7 +26,9 @@ title: Contributors
 ## Contributors
 
 Currently, the following people contributed very significantly to the software in the
-OSCAR project:
+OSCAR project.
+Additionally, people who are financed by the [SFB-TRR 195](https://www.computeralgebra.de/sfb/) mainly work on software
+for the OSCAR project.
 
 {% assign entries = site.data.contributors | sort_natural:"name" %}
 <ul>
@@ -40,30 +42,20 @@ OSCAR project:
         {% assign link_open = true %}
     {% endif %}
     <strong>{{ p.name }}</strong>{% if link_open %}</a>{% assign link_open = false %}{% endif %}
-    {% if p.affiliation != null %} ({{ p.affiliation }}){% endif %}
-  </li>
-{% endfor %}
-</ul>
-
-## Contributors financed by the DFG SFB-TRR 195 (2017 - 2020)
-
-Additionally, the following people were or are financed by the [SFB-TRR 195](https://www.computeralgebra.de/sfb/) to mainly work on software
-for the OSCAR project:
-
-<ul>
-{% for p in site.data.contributors %}
-{% if p.paid_by_dfg == true %}
-  <li>
-    {% if p.website != null %}
-        <a href="{{ p.website }}">
-        {% assign link_open = true %}
-    {% elsif p.email != null %}
-        <a href="mailto:{{ p.email }}">
-        {% assign link_open = true %}
+    {% if p.affiliation != null or p.paid_by_dfg == true %}
+        (
+        {% if p.affiliation != null %}
+            {{ p.affiliation }}
+        {% endif %}
+        {% if p.paid_by_dfg == true %}
+            {% if p.affiliation != null %}
+            ,
+            {% endif %}
+            financed by the <a href="https://www.computeralgebra.de/sfb/">SFB-TRR 195</a>
+        {% endif %}
+        )
     {% endif %}
-    <strong>{{ p.name }}</strong>{% if link_open %}</a>{% assign link_open = false %}{% endif %}
-    {% if p.affiliation != null %} ({{ p.affiliation }}){% endif %}
-  </li>
-{% endif %}
-{% endfor %}
+
+</li>
+    {% endfor %}
 </ul>

--- a/credits.md
+++ b/credits.md
@@ -35,51 +35,6 @@ The following software is used as technical components in the OSCAR project:
 {% endfor %}
 </ul>
 
-## Contributors
-
-Currently, the following people contributed very significantly to the software in the
-OSCAR project:
-
-{% assign entries = site.data.contributors | sort_natural:"name" %}
-<ul>
-{% for p in site.data.contributors %}
-  <li>
-    {% if p.website != null %}
-        <a href="{{ p.website }}">
-        {% assign link_open = true %}
-    {% elsif p.email != null %}
-        <a href="mailto:{{ p.email }}">
-        {% assign link_open = true %}
-    {% endif %}
-    <strong>{{ p.name }}</strong>{% if link_open %}</a>{% assign link_open = false %}{% endif %}
-    {% if p.affiliation != null %} ({{ p.affiliation }}){% endif %}
-  </li>
-{% endfor %}
-</ul>
-
-## Contributors financed by the DFG SFB-TRR 195 (2017 - 2020)
-
-Additionally, the following people were or are financed by the [SFB-TRR 195](https://www.computeralgebra.de/sfb/) to mainly work on software
-for the OSCAR project:
-
-<ul>
-{% for p in site.data.contributors %}
-{% if p.paid_by_dfg == true %}
-  <li>
-    {% if p.website != null %}
-        <a href="{{ p.website }}">
-        {% assign link_open = true %}
-    {% elsif p.email != null %}
-        <a href="mailto:{{ p.email }}">
-        {% assign link_open = true %}
-    {% endif %}
-    <strong>{{ p.name }}</strong>{% if link_open %}</a>{% assign link_open = false %}{% endif %}
-    {% if p.affiliation != null %} ({{ p.affiliation }}){% endif %}
-  </li>
-{% endif %}
-{% endfor %}
-</ul>
-
 ## Citations of Oscar and its components
 
 ### Papers


### PR DESCRIPTION
This move the "contributors" part of the "Credits" page into its own page. Preview at https://rfourquet.github.io/oscar-website/credits/.

cc @micjoswig @fingolfin: did you have in mind something like this?
