### PR TITLE
added notebook TiltingEquivalence

### DIFF
--- a/_data/examples.yml
+++ b/_data/examples.yml
@@ -61,6 +61,13 @@
   thumbnail: Logo_CAP.jpg
   language: CAP using homalg and Singular
 
+- title: "Tilting equivalence"
+  repository: homalg-project/CapHomalgNotebooks
+  filename: TiltingEquivalence
+  author: Kamal Saleh and Mohamed Barakat
+  thumbnail: Logo_CAP.jpg
+  language: CAP using homalg and Singular
+
 - title: "Intro Number Fields: Towers"
   repository: oscar-system/OSCARBinder
   filename: Hecke


### PR DESCRIPTION
relies on the CAP-based GAP packages developed by @kamalsaleh as part of his PhD thesis
* ComplexesCategories
* TriangulatedCategories
* HomotopyCategories
* DerivedCategories