### PR TITLE
classify examples according to "level": intro, etc.

### DIFF
--- a/_data/examples.yml
+++ b/_data/examples.yml
@@ -11,6 +11,7 @@
   author: Michael Joswig
   thumbnail: polymake.png
   language: julia
+  level: 2-intermediate
 
 - title: "Recognizing Manifolds"
   repository: micjoswig/oscar-notebooks
@@ -18,6 +19,7 @@
   author: Michael Joswig
   thumbnail: polymake.png
   language: julia
+  level: 2-intermediate
 
 - title: Singular.jl example
   repository: oscar-system/OSCARBinder
@@ -25,6 +27,7 @@
   author: Sebastian Gutsche
   thumbnail: singular.png
   language: julia
+  level: 1-introduction
 
 - title: "Example AbstractAlgebra.jl"
   repository: oscar-system/OSCARBinder
@@ -32,6 +35,7 @@
   author: William Hart
   thumbnail: AbstractAlgebra.png
   language: julia
+  level: 1-introduction
 
 #- title: "Singular from GAP 1"
 #  repository: oscar-system/OSCARBinder
@@ -53,6 +57,7 @@
   author: Mohamed Barakat
   thumbnail: Logo_CAP.jpg
   language: CAP using homalg and Singular
+  level: 2-intermediate?
 
 - title: "Uniform matrix product states"
   repository: homalg-project/CapHomalgNotebooks
@@ -60,6 +65,7 @@
   author: Mohamed Barakat
   thumbnail: Logo_CAP.jpg
   language: CAP using homalg and Singular
+  level: 3-advanced?
 
 - title: "Tilting equivalence"
   repository: homalg-project/CapHomalgNotebooks
@@ -67,6 +73,7 @@
   author: Kamal Saleh and Mohamed Barakat
   thumbnail: Logo_CAP.jpg
   language: CAP using homalg and Singular
+  level: 3-advanced
 
 - title: "Intro Number Fields: Towers"
   repository: oscar-system/OSCARBinder
@@ -74,6 +81,7 @@
   author: Claus Fieker
   thumbnail: Hecke.png
   language: julia
+  level: 1-introduction
 
 - title: "Combinatorial Automorphisms"
   repository: micjoswig/oscar-notebooks
@@ -81,6 +89,7 @@
   author: Michael Joswig
   thumbnail: polymake.png
   language: julia
+  level: 1-introduction
 
 - title: "Wronski Polynomial Systems"
   repository: micjoswig/oscar-notebooks
@@ -88,6 +97,7 @@
   author: Michael Joswig
   thumbnail: polymake.png
   language: julia
+  level: 2-intermediate
 
 - title: "Example GroebnerBasis.jl"
   repository: ederc/GroebnerBasisNotebooks
@@ -95,6 +105,7 @@
   author: Christian Eder
   thumbnail: GroebnerBasis.png
   language: julia
+  level: 1-introduction
 
 - title: "Computing GIT-Fans"
   repository: oscar-system/GITFans
@@ -102,6 +113,7 @@
   author: Thomas Breuer and Janko Boehm
   thumbnail: oscar.png
   language: julia
+  level: 3-advanced
 
 - title: "Decomposition of Binomial Ideals"
   repository: rfourquet/OSCARBinder
@@ -109,6 +121,7 @@
   author: Clara Petroll
   thumbnail: oscar.png
   language: julia
+  level: 3-advanced
 
 - title: "Tropicalization of a p-adic surface"
   repository: micjoswig/oscar-notebooks
@@ -116,3 +129,4 @@
   author: Michael Joswig
   thumbnail: oscar.png
   language: julia
+  level: 2-intermediate

--- a/_includes/example.html
+++ b/_includes/example.html
@@ -75,7 +75,8 @@ the example, powered by <a href="https://mybinder.org">mybinder</a>.
   {%- else -%}
   {%-     assign someexamples = site.data.examples | where:"thumbnail",page.component -%}
   {%- endif -%}
-  {%- for post in someexamples  -%}
+  {%- assign sortedexamples = someexamples | sort: "level" -%}
+  {%- for post in sortedexamples  -%}
   <div class="item_example_card">
     <a  href="https://nbviewer.jupyter.org/github/{{ post.repository }}/blob/master/{{ post.filename }}.ipynb">
       <img class="item_example-image"


### PR DESCRIPTION
This is a first step to address #113: present first intro-level examples, then more advanced ones. Currently I set up 3 categories: 1-introduction, 2-intermediate, 3-advanced. I definitely need help for classifying the notebooks, as I'm not familiar with many of the math topics used in them. I mostly used "intermediate" for when I'm less sure, but 2 categories might be enough. Or the level could be a simple integer, say from 1 to 5, set by the author.

Also, do we want visual indication of the level besides the order of presentation? If so, should it be written in the cards, or have the cards separated in groups?