### PR TITLE
add 2020 talks by Christian Eder and Janko

### DIFF
--- a/_data/talks.yml
+++ b/_data/talks.yml
@@ -1,3 +1,19 @@
+- title: "msolve - An open source C library for algebraic multivariate system solving"
+  author: Christian Eder
+  date: "2020-11-27"
+  conference: Workshop on Computational Algebra 2020 (virtual)
+  conference_url: https://fachgruppe-computeralgebra.de/ca2020/
+  location: "Kaiserslautern, Germany"
+  pdf_url: https://www.mathematik.uni-kl.de/~ederc/download/workshop-computational-algebra-2020.pdf
+
+- title: "msolve - An open source C library for algebraic multivariate system solving"
+  author: Christian Eder
+  date: "2020-07-13"
+  conference: ICMS 2020 (virtual)
+  conference_url: http://icms-conference.org/2020/
+  location: "Braunschweig, Germany"
+  pdf_url: https://www.mathematik.uni-kl.de/~ederc/download/workshop-computational-algebra-2020.pdf
+
 - title: "Chevalley’s Theorem on constructible images made constructive"
   author: "Mohamed Barakat"
   date: "2020-01-30"
@@ -134,5 +150,3 @@
   author: "Claus Fieker"
   date: "2018-06-08"
   location: "Canada"
-
-

--- a/_data/talks.yml
+++ b/_data/talks.yml
@@ -14,6 +14,13 @@
   location: "Braunschweig, Germany"
   pdf_url: https://www.mathematik.uni-kl.de/~ederc/download/workshop-computational-algebra-2020.pdf
 
+- title: "Massively parallel fan traversals and applications"
+  author: Janko Boehm
+  date: "2020-07-13"
+  conference: ICMS 2020 (virtual)
+  conference_url: http://people.math.binghamton.edu/schroeter/2020ICMS/
+  location: "Braunschweig, Germany"
+
 - title: "Chevalley’s Theorem on constructible images made constructive"
   author: "Mohamed Barakat"
   date: "2020-01-30"

--- a/_data/talks.yml
+++ b/_data/talks.yml
@@ -18,7 +18,7 @@
   author: Janko Boehm
   date: "2020-07-13"
   conference: ICMS 2020 (virtual)
-  conference_url: http://people.math.binghamton.edu/schroeter/2020ICMS/
+  conference_url: http://icms-conference.org/2020/
   location: "Braunschweig, Germany"
 
 - title: "Chevalley’s Theorem on constructible images made constructive"


### PR DESCRIPTION
Preview link: https://rfourquet.github.io/oscar-website/talks/
@ederc : do you like to provide a pdf of your talk (file or url)? Also, I added an url for the "Workshop on Computational Algebra 2020" but there might be a better one?