### PR TITLE
Revamp front page, about page

### DIFF
--- a/about.md
+++ b/about.md
@@ -17,6 +17,8 @@ by combining existing building blocks from any of the cornerstones and
 equip these objects with mathematical capabilities exceeding
 those of the individual systems in a transparent way.
 
+ <img src="{{ site.baseurl }}/public/OSCAR-Organigramm.svg" alt="OSCAR" width="95%" style="margin-left:2%;" align="center">
+
 ## The four cornerstones
 
 This project builds on four leading computer algebra systems which
@@ -44,6 +46,7 @@ interpreted programming language especially suited to algebraic
 applications. It is easy to extend GAP’s functionality; currently over
 120 GAP packages contributed by third party authors are distributed
 with each release.
+GAP is integrated into OSCAR via the [GAP.jl](https://github.com/oscar-system/GAP.jl) Julia package.
 
 The system [polymake](https://polymake.org) is a standard tool for dealing with convex
 polytopes, polyhedral fans, tropical hypersurfaces,
@@ -51,6 +54,7 @@ and related objects from combinatorics and
 geometry. It is designed as a hybrid written in C++ and Perl. A
 sophisticated rule based mechanism decides which low-level C++
 functions are to be called to satisfy user demands.
+Polymake is integrated into OSCAR via the [Polymake.jl](https://github.com/oscar-system/Polymake.jl) Julia package.
 
 [Singular](https://www.singular.uni-kl.de) is a well-established computer algebra system for polynomial
 computations, with particular emphasis on applications in algebraic
@@ -60,6 +64,8 @@ subsystems for non-commutative algebra,
 [LETTERPLACE](https://www.singular.uni-kl.de/Manual/4-1-2/sing_789.htm#SEC841).
 Singular has a kernel written in C++ and provides its own
 interpreted user language. 
+Singular is integrated into OSCAR via the [Singular.jl](https://github.com/oscar-system/Singular.jl) Julia package.
+
 
 ## The role of Julia
 

--- a/contributors.md
+++ b/contributors.md
@@ -25,7 +25,7 @@ title: Contributors
 
 ## Contributors
 
-Currently, the following people contributed very significantly to the software in the
+Currently, the following people contributed significantly to the software in the
 OSCAR project.
 Additionally, people who are financed by the [SFB-TRR 195](https://www.computeralgebra.de/sfb/) mainly work on software
 for the OSCAR project.

--- a/index.md
+++ b/index.md
@@ -10,17 +10,17 @@ system for computations in algebra, geometry, and number theory. In particular,
 the emphasis is on supporting complex computations which require a high level
 of integration of tools from different mathematical areas. 
 
- <img src="{{ site.baseurl }}/public/OSCAR-Organigramm.svg" alt="OSCAR" width="95%" style="margin-left:2%;" align="center">
-
 The project builds on and extends the four cornerstone systems
 
-  * [GAP](https://www.gap-system.org/) - computational discrete algebra
-  * [Singular](https://www.singular.uni-kl.de/) - commutative and non-commutative algebra, algebraic geometry
-  * [Polymake](https://polymake.org/doku.php) - polyhedral geometry
+  * [GAP](https://www.gap-system.org/) - computational discrete algebra (via [GAP.jl](https://github.com/oscar-system/GAP.jl))
+  * [Singular](https://www.singular.uni-kl.de/) - commutative and non-commutative algebra, algebraic geometry (via [Singular.jl](https://github.com/oscar-system/Singular.jl))
+  * [Polymake](https://polymake.org/doku.php) - polyhedral geometry (via [Polymake.jl](https://github.com/oscar-system/Polymake.jl))
   * Antic ([Hecke](https://github.com/thofma/Hecke.jl/), [Nemo](http://nemocas.org)) - number theory
 
-as well as further libraries and packages. Its development, which is still at a very early stage, is supported
-by the Deutsche Forschungsgemeinschaft DFG within the [Collaborative Research Center TRR 195](https://www.computeralgebra.de/sfb/).
+as well as further libraries and packages, which are combined together into the
+[Oscar.jl](https://github.com/oscar-system/Oscar.jl) Julia packages
+
+The development of OSCAR is supported by the Deutsche Forschungsgemeinschaft DFG within the [Collaborative Research Center TRR 195](https://www.computeralgebra.de/sfb/).
 
 See the [About]({{site.baseurl }}/about) page for more information.
 


### PR DESCRIPTION
- the big diagram is "fun" but on the front page it pushes more important
  content too much down; banish it to the About page
- add links to the "adapter" packages GAP.jl, Polymake.jl, Singular.jl
- add links to Oscar.jl
- some other minor tweaks
