### PR TITLE
add a bunch of release news items (WIP, do not yet merge)

### DIFF
--- a/news/_posts/2020-07-06-Oscar-release.md
+++ b/news/_posts/2020-07-06-Oscar-release.md
@@ -1,0 +1,7 @@
+---
+layout: post
+title: Oscar 0.4.0 released
+author: Max Horn
+---
+Today Oscar.jl 0.4.0 was released.
+[Click here for a detailed list of changes](https://github.com/oscar-system/Oscar.jl/releases/tag/v0.4.0).

--- a/news/_posts/2020-08-29-Polymake.jl-0.5-release.md
+++ b/news/_posts/2020-08-29-Polymake.jl-0.5-release.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: Polymake.jl-0.5 release
+title: Polymake.jl 0.5 release
 author: Marek Kaluba
 ---
 `Polymake.jl` v0.5.0 has been released!<br/>

--- a/news/_posts/2020-09-23-Oscar-release.md
+++ b/news/_posts/2020-09-23-Oscar-release.md
@@ -1,0 +1,7 @@
+---
+layout: post
+title: Oscar 0.5.0 released
+author: Max Horn
+---
+Today Oscar.jl 0.5.0 was released.
+[Click here for a detailed list of changes](https://github.com/oscar-system/Oscar.jl/releases/tag/v0.5.0).

--- a/news/_posts/2020-12-11-GAP-release.md
+++ b/news/_posts/2020-12-11-GAP-release.md
@@ -1,0 +1,7 @@
+---
+layout: post
+title: GAP.jl 0.5.0 released
+author: Max Horn
+---
+Today GAP.jl 0.5.0 was released.
+[Click here for a detailed list of changes](https://github.com/oscar-system/GAP.jl/releases/tag/v0.5.0).

--- a/news/_posts/2021-01-07-GAP-release.md
+++ b/news/_posts/2021-01-07-GAP-release.md
@@ -1,0 +1,7 @@
+---
+layout: post
+title: GAP.jl 0.5.1 released
+author: Max Horn
+---
+Today GAP.jl 0.5.1 was released.
+[Click here for a detailed list of changes](https://github.com/oscar-system/GAP.jl/releases/tag/v0.5.1).

--- a/news/_posts/2021-02-12-Oscar-release.md
+++ b/news/_posts/2021-02-12-Oscar-release.md
@@ -1,0 +1,7 @@
+---
+layout: post
+title: Oscar 0.5.1 released
+author: Max Horn
+---
+Today Oscar.jl 0.5.1 was released.
+[Click here for a detailed list of changes](https://github.com/oscar-system/Oscar.jl/releases/tag/v0.5.1).

--- a/news/_posts/2021-02-14-GAP-release.md
+++ b/news/_posts/2021-02-14-GAP-release.md
@@ -1,0 +1,7 @@
+---
+layout: post
+title: GAP.jl 0.5.2 released
+author: Max Horn
+---
+Today GAP.jl 0.5.2 was released.
+[Click here for a detailed list of changes](https://github.com/oscar-system/GAP.jl/releases/tag/v0.5.2).

--- a/news/_posts/2021-02-22-Singular-release.md
+++ b/news/_posts/2021-02-22-Singular-release.md
@@ -13,3 +13,5 @@ for turning a `libSingular.ring_ptr` into a bona fide `Ring`.
 function `AlgebraicFieldExtension`. This function takes a univariate `FunctionField`
 and a minimal polynomial in the function field to create the algebraic extension.
 - Various small bugs have been fixed.
+
+[Click here for a detailed list of changes](https://github.com/oscar-system/Singular.jl/releases/tag/v0.4.5).

--- a/news/_posts/2021-03-06-Singular-release.md
+++ b/news/_posts/2021-03-06-Singular-release.md
@@ -1,0 +1,7 @@
+---
+layout: post
+title: Singular.jl 0.4.6 released
+author: Max Horn
+---
+Today Singular.jl 0.4.6 was released.
+[Click here for a detailed list of changes](https://github.com/oscar-system/Singular.jl/releases/tag/v0.4.6).


### PR DESCRIPTION
Most of them just link to the relevant GitHub releases. That's better than nothing, but by default, these just list the merged PRs and closed issues, which can sometimes be useful and sometimes very confusing.

However, we can edit those, and I did this in a few cases, e.g. 
- https://github.com/oscar-system/Singular.jl/releases/tag/v0.4.5 (copied from the existing news item text written by Dan)
- https://github.com/oscar-system/Singular.jl/releases/tag/v0.4.6 (added by me, @thofma please verify and feel to augment)

I plan to also do this for the GAP.jl releases (i.e. add useful highlevel summaries of the changes in them) tonight or tomorrow, but if someone (e.g. @ThomasBreuer) beats me to it, I won't complain ;-).

But it'd be good to get help with this for the Oscar.jl releases. If anybody feels able to write at least a brief blurb on the changes in 0.5.1 and 0.5.0 (or even 0.4.0, 0.3.0...) please do so, and either edit the release notes directly (i.e., got to for example https://github.com/oscar-system/Oscar.jl/releases/tag/v0.5.1 and click "Edit release" then edit the markdown), or if you don't have the permissions or just are unsure, add a comment here with your suggestion (or email/slack them to me).

