### PR TITLE
Some tweaks, mostly to meetings

### DIFF
--- a/_includes/participants.html
+++ b/_includes/participants.html
@@ -2,8 +2,8 @@
 {% assign participants = include.participants | sort: "name" %}
 {% for p in participants %}
   <li>
-    <strong>{{ p.name }}</strong>
-    {% if p.affiliation != null %} ({{ p.affiliation }}){% endif %}
+    <strong class="participants-{{ p.category }}">{{ p.name }}</strong>
+    {% if p.affiliation != null %} ({{ p.affiliation }}{% if p.category != null %}; {{ p.category }}{% endif %}){% endif %}
     {% if p.links != null %}
         {% for item in p.links %}
             <a href="{{ item[1] }}">({{ item[0] }})</a>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -30,27 +30,6 @@
 
       <a class="sidebar-nav-item{% if page.meeting %} active{% endif %}" href="{{ site.baseurl }}/meetings/">Meetings</a>
 
-      <div class="mobile-hidden">
-        {% if page.meeting %}
-          {% assign pages_list = site.pages | where: "is_meeting_index", "true" | sort:"meeting_nr" %}
-          {% for node in pages_list reversed %}
-          {% if node.title != null %}
-                {% if node.is_meeting_index %}
-                <a class="inner-sidebar-nav-item{% if page.meeting_nr == node.meeting_nr %} active{% endif %}" href="{{ node.url | relative_url }}">{{ node.title }}</a>
-                  {% if node.meeting_nr == page.meeting_nr %}
-                    {% assign subpages = site.pages | where: "meeting_nr", page.meeting_nr | sort:"title" %}
-                    {% for node_inner in subpages %}
-                      {% if node_inner.is_meeting_index != true and node_inner.title != null %}
-                        <a class="inner-sidebar-nav-item-two{% if page.url == node_inner.url %} active{% endif %}" href="{{ node_inner.url | relative_url }}">{{ node_inner.title }}</a>
-                      {% endif %}
-                    {% endfor %}
-                  {% endif %}
-                {% endif %}
-          {% endif %}
-          {% endfor %}
-        {% endif %}
-      </div>
-
       <a class="sidebar-nav-item{% if page.url == '/credits/' %} active{% endif %}" href="{{ site.baseurl }}/credits">Credits</a>
 
       <a class="sidebar-nav-item{% if page.url == '/contributors/' %} active{% endif %}" href="{{ site.baseurl }}/contributors">Contributors</a>

--- a/_layouts/meeting-home.html
+++ b/_layouts/meeting-home.html
@@ -1,1 +1,0 @@
-page.html

--- a/_layouts/meeting.html
+++ b/_layouts/meeting.html
@@ -2,11 +2,15 @@
 layout: default
 ---
 
-{% if page.is_meeting_index != true %}
-{% assign parent_dir = page.path | remove: page.name | prepend: "/" %}
-{% assign parent = site.pages | where: "dir", parent_dir | first %}
-<a href="{{ site.baseurl }}{{ parent.url }}">Back to "{{parent.title}}"</a>
-{% endif %}
+{% assign meeting_pages = site.pages | where: "meeting_nr", page.meeting_nr | sort: "name" %}
+{% assign parent = meeting_pages | where: "is_meeting_index", "true" | first %}
+
+<a href="{{ parent.url | relative_url }}">{{parent.title}}</a>
+{% for p in meeting_pages %}
+    {% if p.is_meeting_index != true %}
+       | <a href="{{ p.url | relative_url }}">{{p.title}}</a>
+    {% endif %}
+{% endfor %}
 
 <div class="page">
 {% if page.is_meeting_index != true %}

--- a/_layouts/meeting.html
+++ b/_layouts/meeting.html
@@ -5,10 +5,10 @@ layout: default
 {% assign meeting_pages = site.pages | where: "meeting_nr", page.meeting_nr | sort: "name" %}
 {% assign parent = meeting_pages | where: "is_meeting_index", "true" | first %}
 
-<a href="{{ parent.url | relative_url }}">{{parent.title}}</a>
+<a href="{{ parent.url | relative_url }}">{{ parent.title }}</a>
 {% for p in meeting_pages %}
     {% if p.is_meeting_index != true %}
-       | <a href="{{ p.url | relative_url }}">{{p.title}}</a>
+       | <a href="{{ p.url | relative_url }}">{{ p.title }}</a>
     {% endif %}
 {% endfor %}
 

--- a/meetings.md
+++ b/meetings.md
@@ -5,23 +5,10 @@ meeting: true
 ---
 
 <ol reversed>
-    {% assign pages_list = site.pages | sort: "meeting_nr" %}
+    {% assign pages_list = site.pages | where: "is_meeting_index", "true" | sort: "meeting_nr" %}
     {% for node in pages_list reversed %}
         {% if node.title != null %}
-            {% if node.is_meeting_index %}
-                <li>
-                    <a href="{{ node.url  | relative_url }}">{{ node.title }}</a>
-                    <ul>
-                    {% for node_inner in pages_list %}
-                        {% if node_inner.meeting_nr == node.meeting_nr and node_inner.is_meeting_index != true %}
-                            <li>
-                                <a href="{{ node_inner.url | relative_url }}">{{node_inner.title}}</a>
-                            </li>
-                        {% endif %}
-                    {% endfor %}
-                    </ul>
-                </li>
-            {% endif %}
+            <li><a href="{{ node.url  | relative_url }}">{{ node.title }}</a></li>
         {% endif %}
     {% endfor %}
 </ol>

--- a/meetings/2021-09/participants.md
+++ b/meetings/2021-09/participants.md
@@ -4,12 +4,12 @@ title: Participants
 meeting: true
 meeting_nr: 202109
 people:
-    - {name: Claus Fieker, affiliation: TU Kaiserslautern}
-    - {name: Max Horn, affiliation: TU Kaiserslautern}
-    - {name: Thomas Breuer, affiliation: RWTH Aachen}
-    - {name: Tommy Hofmann, affiliation: TU Kaiserslautern}
-    - {name: Eamonn O'Brien, affiliation: University of Auckland}
-    - {name: Clément Pernet, affiliation: Université Grenoble Alpes}
+    - {name: Claus Fieker, affiliation: TU Kaiserslautern, category: organizer}
+    - {name: Max Horn, affiliation: TU Kaiserslautern, category: organizer}
+    - {name: Thomas Breuer, affiliation: RWTH Aachen, category: organizer}
+    - {name: Tommy Hofmann, affiliation: TU Kaiserslautern, category: organizer}
+    - {name: Eamonn O'Brien, affiliation: University of Auckland, category: speaker}
+    - {name: Clément Pernet, affiliation: Université Grenoble Alpes, category: speaker}
     - {name: Alheydis Geiger, affiliation: Tübingen}
     - {name: Simon Telen, affiliation: MPI Leipzig}
     - {name: Dominik Bernhardt, affiliation: RWTH Aachen}

--- a/public/css/hyde.css
+++ b/public/css/hyde.css
@@ -432,3 +432,12 @@ a.sidebar-nav-item:focus {
     max-width: 30%;
   }
 } */
+
+
+.participants-organizer {
+  color: blue;
+}
+
+.participants-speaker {
+  color: green;
+}


### PR DESCRIPTION
- Remove unused _layouts/meeting-home.html
- Add top navigation to meeting pages
- On meetings overview page, don't list all subpages
- Remove separate meeting entries from navbar
- Meetings: highlight organizers/speakers in participants list

Resolves #174

For a preview, [see here](https://fingolfin.github.io/oscar-website/meetings/2021-09/)