### PR TITLE
fix test for julia exercise 7

### DIFF
--- a/meetings/2021-09/exercises.md
+++ b/meetings/2021-09/exercises.md
@@ -226,7 +226,7 @@ You may wish to consult the [Julia documentation](https://docs.julialang.org/en/
 
   ```julia
   g = cached(+)
-  println(g(1, 1)) == 1 + 1
+  println(g(1, 1) == 1 + 1)
   ```
 
   To check the caching, try the following function:


### PR DESCRIPTION
The original code
```julia
g = cached(+)
println(g(1, 1)) == 1 + 1
```
compares `nothing` (the return value of `println`) to 2.