### PR TITLE
fix types in ex 9

### DIFF
--- a/meetings/2021-09/exercises.md
+++ b/meetings/2021-09/exercises.md
@@ -405,14 +405,14 @@ You may wish to consult the [Oscar documentation](https://oscar-system.github.io
   The goal of this exercise is to implement $R \times S$, the product of two commutative rings $R$ and $S$.
 
   ```julia
-  mutable struct ProdRing{S, T} <: Ring
+  mutable struct ProdRing{S, T} <: AbstractAlgebra.Ring
     first::S
     second::T
   end
   ```
 
   ```julia
-  mutable struct ProdRingElem{U, V} <: RingElement
+  mutable struct ProdRingElem{U, V} <: AbstractAlgebra.RingElem
     first::U
     second::V
     parent


### PR DESCRIPTION
maybe change even to 
`mutable struct ProdRing{S <: AbstractAlgebra.Ring, T <: AbstractAlgebra.Ring} <: AbstractAlgebra.Ring`

and vice verse for ProdRingElem