### PR TITLE
added one more link to Oscar documentation

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -5,7 +5,7 @@ title: Documentation
 
 You can find the OSCAR manual here:
  - [for the latest development version of Oscar.jl](https://oscar-system.github.io/Oscar.jl/dev)
-<!-- - [for the latest stable release of Oscar.jl](https://oscar-system.github.io/Oscar.jl/latest) -->
+ - [for the latest stable release of Oscar.jl](https://oscar-system.github.io/Oscar.jl/stable)
 
 Note that an aim of OSCAR is to combine and extend the capabilities of
 Antic (<a href="https://github.com/thofma/Hecke.jl/">Hecke</a>,


### PR DESCRIPTION
On the Documentation page, there was only a link to the dev. version of Oscar.
Now there is enough contents in the documentation of the stable version,
thus a link to this version is appropriate.