### PR TITLE
Add tutorial on toric geometry

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -19,6 +19,8 @@
       <a class="sidebar-nav-item{% if page.url == '/news/' %} active{% endif %}" href="{{ site.baseurl }}/news/">News</a>
 
       <a class="sidebar-nav-item{% if page.url == '/install/' %} active{% endif %}" href="{{ site.baseurl }}/install/">Installation</a>
+      
+      <a class="sidebar-nav-item{% if page.url == '/tutorials/' %} active{% endif %}" href="{{ site.baseurl }}/tutorials/">Tutorials</a>
 
       <a class="sidebar-nav-item{% if page.url contains '/example/' %} active{% endif %}" href="{{ site.baseurl }}/example/">Examples</a>
 

--- a/tutorials.md
+++ b/tutorials.md
@@ -1,0 +1,8 @@
+---
+layout: page
+title: Tutorials
+---
+
+Here is a list of tutorials (all [Jupyter notebooks](https://jupyter.org/)) on selected topics:
+
+1. [Toric geometry](https://nbviewer.jupyter.org/github/oscar-system/oscar-website/blob/gh-pages/tutorials/ToricGeometryInOSCAR.ipynb) (by Martin Bies).

--- a/tutorials/ToricGeometryInOSCAR.ipynb
+++ b/tutorials/ToricGeometryInOSCAR.ipynb
@@ -1,0 +1,3847 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6f3718b4",
+   "metadata": {},
+   "source": [
+    "# Tutorial: Toric geometry in OSCAR"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 115,
+   "id": "bd3322fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "using Oscar"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1b3246b",
+   "metadata": {},
+   "source": [
+    "# 1 Affine toric varieties"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01ac12be",
+   "metadata": {},
+   "source": [
+    "Any geometry course (analytic geometry, algebraic geometry and of course toric geometry too) begins with the study of affine varieties/schemes. So we first recall that affine toric varieties are encoded by rational polyhedral cones.\n",
+    "\n",
+    "Specifically, let us state theorem 1.2.18 of the book *Toric Varieties* by David Cox, John Little and Hal Schenck:\n",
+    "\n",
+    "Let $\\sigma \\subseteq N_{\\mathbb{R}} \\cong \\mathbb{R}^n$ be a rational polyhedral cone with semigroup $S_\\sigma = \\sigma^\\vee \\cap M$. Then the associated affine toric variety $U_\\sigma$ is given by\n",
+    "\n",
+    "$$ U_\\sigma = \\mathrm{Spec} \\left(\\mathbb{C} \\left[ S_\\sigma \\right]\\right) = \\mathrm{Spec} \\left(\\mathbb{C} \\left[ \\sigma^\\vee \\cap M \\right]\\right) \\, .$$\n",
+    "\n",
+    "In particular, it holds\n",
+    "\n",
+    "$$\\mathrm{dim}( U_\\sigma ) = n \\, \\Leftrightarrow \\, \\text{the torus of $U_\\sigma$ is } T_N = N \\otimes_{\\mathbb{Z}} \\mathbb{C}^\\ast \\, \\Leftrightarrow \\, \\sigma \\text{ is strongly convex.}$$\n",
+    "\n",
+    "As per usual, we focus on *strongy convex* polyhedral cones $\\sigma$, so that $T_N$ is the algebraic torus of $U_\\sigma$."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd6d25b2",
+   "metadata": {},
+   "source": [
+    "## 1.1 Constructing affine toric varieties"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "87af490a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A polyhedral cone in ambient dimension 2"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    " C = positive_hull([1 0; 0 1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8c12f35f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A normal, affine toric variety"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    " antv = AffineNormalToricVariety(C)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27cdee35",
+   "metadata": {},
+   "source": [
+    "## 1.2 Properties and attributes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cec721c2",
+   "metadata": {},
+   "source": [
+    "The cone $\\sigma$ encodes a lot of information about the affine toric variety $U_\\sigma$. In the background, OSCAR conducts such investigations in polyhedral geometry with Polymake (cf. https://polymake.org/doku.php/start). This allows to access a lot of properties of affine toric varieties. Here are a few examples"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a04652f4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_smooth(antv)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "2f39b2fe",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "false"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_complete(antv)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "90757e21",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_simplicial(antv)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c60aee82",
+   "metadata": {},
+   "source": [
+    "We can also look for polynomials that cut out this affine variety in $\\mathbb{C}^k$ for suitable integer $k$. The ideal, which cuts out the affine variety in question is nothing but the toric ideal. We compute it as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "0d1a6293",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ideal(0)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "toric_ideal(antv)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "514cfe40",
+   "metadata": {},
+   "source": [
+    "This means, that the variety *antv* is nothing but $\\mathbb{C}^2$. Here is a more interesting example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "386539c8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A polyhedral cone in ambient dimension 2"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "C2 = positive_hull([1 1; -1 1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "f393b3b0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A normal, affine toric variety"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "antv2 = AffineNormalToricVariety(C2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "6eeea25e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "false"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_smooth(antv2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "81fb971c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_simplicial(antv2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "cbd5268b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ideal(-x1*x2 + x3^2)"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "toric_ideal(antv2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75760f69",
+   "metadata": {},
+   "source": [
+    "So in $\\mathbb{C}^3$ with coordinate ring $\\mathbb{C}[ x_1, x_2, x_3 ]$ we are looking at the variety $X = V( - x_1 x_2 + x_3^2  )$. This is a rather classical example of a simplicial, affine toric variety."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f12b883",
+   "metadata": {},
+   "source": [
+    "# 2 The projective space"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fadfad9f",
+   "metadata": {},
+   "source": [
+    "More general toric varieties are constructed by providing not only one strongly convex polyhedral cone, but a collection of \"compatible\" cones. Such a collection is termed a (strongly convex polyhedral) fan.\n",
+    "\n",
+    "We give details on how to create fans and the corresponding toric varieties in section 3 of this tutorial. To build intuition, instead we focus on the projective space first and demonstrate the existing functionality with this space. Specifically, in this section we focus on the projective space $\\mathbb{P}^2$."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13866e6b",
+   "metadata": {},
+   "source": [
+    "## 2.1 Constructing the projective space "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c58a1631",
+   "metadata": {},
+   "source": [
+    "We construct the projective space as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "2fff056f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "P2 = projective_space(NormalToricVariety, 2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a11cd23",
+   "metadata": {},
+   "source": [
+    "As you can notice, upon creation a lot of information on this space is already known.\n",
+    "\n",
+    "Notice that the constructor expects us to state as first argument *NormalToricVariety*. This is to tell OSCAR that we want the projective space as toric variety.\n",
+    "\n",
+    "This is a design decision that was taken after careful consideration. Namely, the projective space could in principle be constructed as a scheme (with an arbitrary coefficient ring) or merely as space parametrized by homogeneous coordinates. Depending on which of these perspectives is desired, specializes algorithms may be available. As of February 2023, there are many specialized toric algorithms. So in this regard, provinding *NormalToricVariety* as first argument ensures that we can perform a large number of computations."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70b7fd79",
+   "metadata": {},
+   "source": [
+    "## 2.2 Properties and attributes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23f17fcc",
+   "metadata": {},
+   "source": [
+    "We can check for properties by invoking \"is_\" followed by the property that we want to compute. Here are a few examples:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "f7507d2b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "false"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_affine(P2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "d246d1f3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_smooth(P2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "055158b8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_projective(P2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ce3b10c",
+   "metadata": {},
+   "source": [
+    "An exception to this rule is the torusfactor. Namely, since the terminology is to ask for \"having a torusfactor\", we have to invoke:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "bb12c962",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "false"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "has_torusfactor(P2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd19627d",
+   "metadata": {},
+   "source": [
+    "A simple attriute that we would like to access is the dimension of the space:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "3bda02cc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dim(P2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2957ec7e",
+   "metadata": {},
+   "source": [
+    "The next interesting class of attributes concern the divisors on toric varieties. Let us turn to them next."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "31454363",
+   "metadata": {},
+   "source": [
+    "## 2.3 The groups of Weil and Cartier divisors"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27612484",
+   "metadata": {},
+   "source": [
+    "The group of the torus invariant Weil divisors $\\mathrm{Div}_T(\\mathbb{P}^2)$ can be accessed as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "73df96b6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "GrpAb: Z^3"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "WeilDivisors = torusinvariant_weil_divisor_group(P2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "e44c310c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "GrpAb: Z^3"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "CartierDivisors = torusinvariant_cartier_divisor_group(P2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8eda8764",
+   "metadata": {},
+   "source": [
+    "As you can see, the return value is merely a free Abelian group. To properly read/interpret the group of Weil divisors, we want to know the mapping of the Weil divisors into the class group:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "4d121b10",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Map with following data\n",
+       "Domain:\n",
+       "=======\n",
+       "WeilDivisors\n",
+       "Codomain:\n",
+       "=========\n",
+       "Abelian group with structure: Z"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f1 = map_from_torusinvariant_weil_divisor_group_to_class_group(P2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0394386",
+   "metadata": {},
+   "source": [
+    "To see the mapping prescription, we can access the matrix of this map:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "44633dd2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[1]\n",
+       "[1]\n",
+       "[1]"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "matrix(f1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44a08404",
+   "metadata": {},
+   "source": [
+    "This means, that there are 3 torus invariant Weil divisors $D_1$, $D_2$, $D_3$ for $\\mathbb{P}^2$ (each corresponding to a ray in the fan of $\\mathbb{P}^2$). The map to the class group assigns each of these the same divisor class, i.e. $[D_1] = [D_2] = [D_3]$. Or put differently, the Weil divisors $D_1$, $D_2$, $D_3$ are linearly equivalent: $D_1 \\sim D_2 \\sim D_3$.\n",
+    "\n",
+    "Of course, we can also use this information to find the Class group $\\mathrm{Cl} ( \\mathbb{P}^2 )$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "283ccebc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "GrpAb: Z"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "class_group(P2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c61b200",
+   "metadata": {},
+   "source": [
+    "Similarly, we want to understand how the group of torus invariant Cartier divisors $\\mathrm{Div}_T(\\mathbb{P}^2)$ map to the Picard group:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "3f9d50be",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Map with following data\n",
+       "Domain:\n",
+       "=======\n",
+       "WeilDivisors\n",
+       "Codomain:\n",
+       "=========\n",
+       "Abelian group with structure: Z"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f2 = map_from_cartier_divisor_group_to_picard_group(P2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "a9df2d5c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[1]\n",
+       "[1]\n",
+       "[1]"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "matrix(f2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7ec2b3d",
+   "metadata": {},
+   "source": [
+    "With this, we can also find the Picard group $\\mathrm{Pic} ( \\mathbb{P}^2 )$ of the projective space:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "0a4b0bdb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "GrpAb: Z"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "picard_group(P2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1acc118e",
+   "metadata": {},
+   "source": [
+    "Recall that $\\mathbb{P}^2$ is smooth. Therefore, Cartier and Weil divisors coincide. Indeed, we can see this by considering the map from the Cartier to the Weil divisors:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "40cc9d48",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Map with following data\n",
+       "Domain:\n",
+       "=======\n",
+       "WeilDivisors\n",
+       "Codomain:\n",
+       "=========\n",
+       "WeilDivisors"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f3 = map_from_torusinvariant_cartier_divisor_group_to_torusinvariant_weil_divisor_group(P2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "4b3b02c3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[1   0   0]\n",
+       "[0   1   0]\n",
+       "[0   0   1]"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "matrix(f3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a65c7301",
+   "metadata": {},
+   "source": [
+    "At times, it will be interesting to find a torus invariant Weil divisor $D$ that represents a certain divisor class. This is possible because $f_1$ is surjective:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "bfb6d2c1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_surjective(f1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59245e50",
+   "metadata": {},
+   "source": [
+    "Hence, for every $x \\in \\mathrm{Cl}(\\mathbb{P}^2)$, there is a $y \\in \\mathrm{Div}_T(\\mathbb{P}^2)$ with $f_1(y) = x$. We can compute such preimages:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "75425fdb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1-element Vector{GrpAbFinGenElem}:\n",
+       " Element of WeilDivisors with components [1 0 0]"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[preimage(f1,x) for x in gens(class_group(P2))]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "054e4683",
+   "metadata": {},
+   "source": [
+    "Alternatively, we can even find the preinverse of $f_1$ directly:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "e7490bcc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[1   0   0]"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "matrix(preinverse(f1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d720827",
+   "metadata": {},
+   "source": [
+    "This functionality is particularly useful in the context of toric line bundles, i.e. the elements of $\\mathrm{Pic}(\\mathbb{P}^2)$. We will line bundles momentarily.\n",
+    "\n",
+    "We complete this section by briefly mentioning the character lattice $N(\\mathbb{P}^2)$. Since $\\mathbb{P}^2$ has no torusfactor, there is a short exact sequence:\n",
+    "\n",
+    "$$0 \\to N(\\mathbb{P}^2) \\hookrightarrow \\mathrm{Div}_T( \\mathbb{P}^2 ) \\twoheadrightarrow \\mathrm{Cl} ( \\mathbb{P}^2 ) \\to 0.$$\n",
+    "\n",
+    "The map $N(\\mathbb{P}^2) \\hookrightarrow \\mathrm{Div}_T( \\mathbb{P}^2 )$ can be computed as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "0885bf20",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Map with following data\n",
+       "Domain:\n",
+       "=======\n",
+       "Abelian group with structure: Z^2\n",
+       "Codomain:\n",
+       "=========\n",
+       "WeilDivisors"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "f4 = map_from_character_lattice_to_torusinvariant_weil_divisor_group(P2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "ee225293",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_injective(f4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "f4b82bcc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "false"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_surjective(f4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "092c219c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[1   0   -1]\n",
+       "[0   1   -1]"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "matrix(f4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ad5fde4",
+   "metadata": {},
+   "source": [
+    "You should notice the columns of this matrix as the ray generators of the projective space $\\mathbb{P}^2$."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6cd0092d",
+   "metadata": {},
+   "source": [
+    "## 2..4 Divisor classes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02348463",
+   "metadata": {},
+   "source": [
+    "Let us now create a torusinvariant Weil divisor on the projective space. Recall that there are 3 generators $D_1$, $D_2$ and $D_3$ of the torusinvariant Weil divisors. Hence, the general Weil divisor is of the form $a_1 D_1 + a_2 D_2 + a_3 D_3$ with $a_1, a_2, a_3 \\in \\mathbb{Z}$. The constructor of the toric divsior expects the list $[a_1, a_2, a_3]$ as second argument.\n",
+    "\n",
+    "Let us now create the torusinvariant Weil divisor $D = 1 D_1 + 2 D_2 + 3 D_3$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "d0ea6e65",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A torus-invariant, non-prime divisor on a normal toric variety"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "D = ToricDivisor(P2,[1,2,3])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1c7c87c",
+   "metadata": {},
+   "source": [
+    "We support various properties and attributes for such a divisor:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "be31a562",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_ample(D)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "5c0cf695",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_very_ample(D)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "0b5ac695",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_cartier(D)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "675e5a95",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "false"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_principal(D)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "e4d5e530",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3-element Vector{fmpz}:\n",
+       " 1\n",
+       " 2\n",
+       " 3"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "coefficients(D)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0807874d",
+   "metadata": {},
+   "source": [
+    "In particular we can compute the divsior class associated to this divisor:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "2023e857",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A divisor class on a normal toric variety"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "DC = ToricDivisorClass(D)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "695626e4",
+   "metadata": {},
+   "source": [
+    "The task of finding a divisor in this divisor class is exactly the question of inverting the map $f_1$ introduced above. This is handled behind the scenes with the following command:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "562a3509",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A torus-invariant, non-prime divisor on a normal toric variety"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "D2 = toric_divisor(DC)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d2dd009",
+   "metadata": {},
+   "source": [
+    "Note that $D_2$ and $D$ are not identical:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "93ab1ec0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "false"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "D == D2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63c07f21",
+   "metadata": {},
+   "source": [
+    "We can see this explicitly, by asking for the coefficients of $D_2$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "995a13a1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3-element Vector{fmpz}:\n",
+       " 6\n",
+       " 0\n",
+       " 0"
+      ]
+     },
+     "execution_count": 48,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "coefficients(D2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "90d91fab",
+   "metadata": {},
+   "source": [
+    "However, $D \\sim D_2$. This is the case since $D - D_2$ is a principal divisor:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "976234e7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_principal(D - D2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "debf19bb",
+   "metadata": {},
+   "source": [
+    "So, as expected $[D] = [D_2]$."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6a284d3",
+   "metadata": {},
+   "source": [
+    "## 2.5 Line bundles "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e80fc043",
+   "metadata": {},
+   "source": [
+    "Line bundles are the elements of the Picard group $\\mathrm{Pic}( \\mathbb{P}^2 )$. They are created similarly to Weil divisor. First recall that we can compute the Picard group $\\mathrm{Pic}(\\mathbb{P}^2)$ in OSCAR as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "4a9c565c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "GrpAb: Z"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "picard_group(P2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "083136dd",
+   "metadata": {},
+   "source": [
+    "Hence, this group has a single generator $G = \\mathcal{O}_{\\mathbb{P}^2}(1)$ and every element in this group is of the form $G^a = G \\otimes \\dots \\otimes G = \\mathcal{O}_{\\mathbb{P}^2}(a)$ with $a \\in \\mathbb{Z}$. Therefore, the constructor for line bundles on the projective space expects $[a]$ as input. For instance, the following creates the line bundle $\\mathcal{L} = \\mathcal{O}_{\\mathbb{P}^2}(1)$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "ffe01311",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A toric line bundle on a normal toric variety"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "L = ToricLineBundle(P2,[1]) "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "895abcee",
+   "metadata": {},
+   "source": [
+    "Again, various properties and attributes are supported for line bundles. For example, we can check if a line bundle is the trivial line bundle (i.e. the zero element in the Picard group):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "id": "ffb7372e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "false"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_trivial(L)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4ceaad5",
+   "metadata": {},
+   "source": [
+    "Other properties are accessed by computing a divisor (class) corresponding to the line bundle in question (i.e. inverting the map $\\mathrm{CDiv}( \\mathbb{P}^2 ) \\to \\mathrm{Pic}( \\mathbb{P}^2 )$):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "1c96c57e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A torus-invariant, cartier, non-principal, prime divisor on a normal toric variety"
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "toric_divisor(L)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "id": "609c75ab",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Element of\n",
+       "GrpAb: Z\n",
+       "with components [1]"
+      ]
+     },
+     "execution_count": 54,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "divisor_class(L)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99c507eb",
+   "metadata": {},
+   "source": [
+    "Among others, ampleness of a line bundle is checked by checking it for the underlying divisor:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "id": "adb2b460",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_ample(L)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "id": "b1b942de",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_very_ample(L)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4751613d",
+   "metadata": {},
+   "source": [
+    "Another example is the degree of the line bundle:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "id": "92714585",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "degree(L)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3db328f8",
+   "metadata": {},
+   "source": [
+    "## 2.6 Line bundle cohomology with cohomCalg"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "666b495d",
+   "metadata": {},
+   "source": [
+    "To compute line bundle cohomology, we use the cohomCalg algorithm (cf. https://github.com/BenjaminJurke/cohomCalg). It is executed as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "id": "c4d97a06",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3-element Vector{fmpz}:\n",
+       " 3\n",
+       " 0\n",
+       " 0"
+      ]
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "all_cohomologies(L)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04043994",
+   "metadata": {},
+   "source": [
+    "This means that $h^0( \\mathbb{P}^2, \\mathcal{L} ) = 3$ and $h^1( \\mathbb{P}^2, \\mathcal{L} ) = h^2( \\mathbb{P}^2, \\mathcal{L} ) = 0$. This result is of course well-known to the experts. This functionality works as long as the variety in question is either (smooth and complete) or (simplicial and projective).\n",
+    "\n",
+    "Of course, we can also compute just some of the line bundle cohomologies. For instance, the following finds $h^0( \\mathbb{P}^2, \\mathcal{L} )$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "id": "e98bfca4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 59,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cohomology(L,0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee4e6e1d",
+   "metadata": {},
+   "source": [
+    "The Cox ring of the toric variety is very important. It is the algebraic counterpart to the structure sheaf $\\mathcal{O}_{\\mathbb{P}^2}$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "id": "29a8dc10",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Multivariate Polynomial Ring in x1, x2, x3 over Rational Field graded by \n",
+       "  x1 -> [1]\n",
+       "  x2 -> [1]\n",
+       "  x3 -> [1]"
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cox_ring(P2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4451271b",
+   "metadata": {},
+   "source": [
+    "As such, it comes at no surprise that a basis of the global sections of line bundles can be found from the homogeneous components of the Cox ring. An alternative methods exists via Laurent monomials. Both options are available within OSCAR:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "id": "e8adc2f5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3-element Vector{MPolyElem_dec{fmpq, fmpq_mpoly}}:\n",
+       " x3\n",
+       " x2\n",
+       " x1"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "basis_of_global_sections_via_homogeneous_component(L)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "id": "cdb4bd92",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3-element Vector{MPolyQuoElem{fmpq_mpoly}}:\n",
+       " x1_\n",
+       " x2*x1_\n",
+       " 1"
+      ]
+     },
+     "execution_count": 62,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "basis_of_global_sections_via_rational_functions(L)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cfb244cf",
+   "metadata": {},
+   "source": [
+    "For convenience, the default is to use the homogeneous components. That is:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "id": "9dcf5d1d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3-element Vector{MPolyElem_dec{fmpq, fmpq_mpoly}}:\n",
+       " x3\n",
+       " x2\n",
+       " x1"
+      ]
+     },
+     "execution_count": 63,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "basis_of_global_sections(L)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17cc5a0b",
+   "metadata": {},
+   "source": [
+    "## 2.7 The fan"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2eba4c5",
+   "metadata": {},
+   "source": [
+    "We now come back to constructing more general toric varieties. As mentioned above, this in general relies on the construction of a fan consisting of strongly convex polyhedral cones. This polyhedral geometry is the backbone for many computations in toric geometry. Sure enough, you can compute therefore compute the fan of a toric variety. For the projective space $\\mathbbb{P}^2$, to this end we issue the following:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "id": "0a74c277",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A polyhedral fan in ambient dimension 2"
+      ]
+     },
+     "execution_count": 64,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fan_of_P2 = fan(P2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6ec0692",
+   "metadata": {},
+   "source": [
+    "You can visualize this fan by invoking the command *visualize(f)*. This will (most likely) open a separate window with an illustration of the fan. Alternatively, we can investigate the fan in more details by computing is rays and maximal cones:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "id": "86663d07",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3-element SubObjectIterator{RayVector{fmpq}}:\n",
+       " [1, 0]\n",
+       " [0, 1]\n",
+       " [-1, -1]"
+      ]
+     },
+     "execution_count": 65,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rays(fan_of_P2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "id": "4dc823b7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3-element SubObjectIterator{Cone{fmpq}}:\n",
+       " A polyhedral cone in ambient dimension 2\n",
+       " A polyhedral cone in ambient dimension 2\n",
+       " A polyhedral cone in ambient dimension 2"
+      ]
+     },
+     "execution_count": 66,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "maximal_cones(fan_of_P2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "id": "366f8954",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3-element Vector{SubObjectIterator{RayVector{fmpq}}}:\n",
+       " [[1, 0], [0, 1]]\n",
+       " [[0, 1], [-1, -1]]\n",
+       " [[1, 0], [-1, -1]]"
+      ]
+     },
+     "execution_count": 67,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[rays(c) for c in maximal_cones(fan_of_P2)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "447b9f54",
+   "metadata": {},
+   "source": [
+    "Indeed, this is the famous fan of the projective space $\\mathbb{P}^2$."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e2bfeac2",
+   "metadata": {},
+   "source": [
+    "# 3 Constructing more general toric varieties"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ecd714e",
+   "metadata": {},
+   "source": [
+    "## 3.1 $\\mathbb{P}^2$ from a fan"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "092572b7",
+   "metadata": {},
+   "source": [
+    "As an example, let us create the projective space by first constructing its fan and then building the variety directly from this fan. This proceeds as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "id": "8788d277",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A normal toric variety"
+      ]
+     },
+     "execution_count": 70,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ray_generators = [[1, 0], [0, 1], [-1, -1]]\n",
+    "max_cones = [[1, 2], [2, 3], [3, 1]]\n",
+    "X = NormalToricVariety(ray_generators, max_cones)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e1f2c1c",
+   "metadata": {},
+   "source": [
+    "When created in this way, the variety \"knows\" less information than by using the standard constructor projective_space()\", as demonstrated in the previous section. The reason is that by providing the fan, we can construct all sorts of toric varieties. But we can of course compute the necessary information to convince ourselves that this indeed is the projective space $\\mathbb{P}^2$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "id": "8e7161a1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true"
+      ]
+     },
+     "execution_count": 71,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_projective(X)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 72,
+   "id": "a25915fe",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true"
+      ]
+     },
+     "execution_count": 72,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_smooth(X)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 73,
+   "id": "8ae4ef3f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 73,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dim(X)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
+   "id": "2f9d0238",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "GrpAb: Z"
+      ]
+     },
+     "execution_count": 74,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "class_group(X)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
+   "id": "93402cb5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "GrpAb: Z^3"
+      ]
+     },
+     "execution_count": 75,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "torusinvariant_weil_divisor_group(X)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 76,
+   "id": "fddc4772",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Multivariate Polynomial Ring in x1, x2, x3 over Rational Field graded by \n",
+       "  x1 -> [1]\n",
+       "  x2 -> [1]\n",
+       "  x3 -> [1]"
+      ]
+     },
+     "execution_count": 76,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cox_ring(X)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "188baebd",
+   "metadata": {},
+   "source": [
+    "## 3.2 Del Pezzo surfaces "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97841eaf",
+   "metadata": {},
+   "source": [
+    "We provide a standard constructor for del Pezzo surfaces. For instance, we can issue:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 77,
+   "id": "758338e3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor"
+      ]
+     },
+     "execution_count": 77,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dP3 = del_pezzo_surface(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "211211ff",
+   "metadata": {},
+   "source": [
+    "To demonstrate that the line bundle cohomology computations also work in such more general settings, let us compute a toric line bundle and computes its cohomologies:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 78,
+   "id": "d39239ef",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "GrpAb: Z^4"
+      ]
+     },
+     "execution_count": 78,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "picard_group(dP3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "id": "c41eda83",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A toric line bundle on a normal toric variety"
+      ]
+     },
+     "execution_count": 79,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "L2 = ToricLineBundle(dP3, [1,2,3,4])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 80,
+   "id": "faa01be0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3-element Vector{fmpz}:\n",
+       " 0\n",
+       " 16\n",
+       " 0"
+      ]
+     },
+     "execution_count": 80,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "all_cohomologies(L2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba7e87fd",
+   "metadata": {},
+   "source": [
+    "## 3.3 Hirzebruch surfaces"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2a94106",
+   "metadata": {},
+   "source": [
+    "Similarly, we can also construct Hirzebruch surfaces:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 91,
+   "id": "dbbe622c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A normal, non-affine, smooth, projective, gorenstein, non-fano, 2-dimensional toric variety without torusfactor"
+      ]
+     },
+     "execution_count": 91,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "F2 = hirzebruch_surface(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f55c72f",
+   "metadata": {},
+   "source": [
+    "## 3.4 Toric blowups"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e86a586",
+   "metadata": {},
+   "source": [
+    "A star subdivision allows to conduct a toric blowup. The relevant functionality is available in OSCAR. To this end let us look at the projective space anew:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 81,
+   "id": "d4670946",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor"
+      ]
+     },
+     "execution_count": 81,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "P2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 82,
+   "id": "102f0b2c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Multivariate Polynomial Ring in x1, x2, x3 over Rational Field graded by \n",
+       "  x1 -> [1]\n",
+       "  x2 -> [1]\n",
+       "  x3 -> [1]"
+      ]
+     },
+     "execution_count": 82,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cox_ring(P2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f456d86",
+   "metadata": {},
+   "source": [
+    "Let us now perform a blowup of the locus $V( x_1, x_2 )$. This is done as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 84,
+   "id": "33bdb050",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A normal toric variety"
+      ]
+     },
+     "execution_count": 84,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "BP2 = blowup_on_ith_minimal_torus_orbit(P2, 1, \"e\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "beafefdf",
+   "metadata": {},
+   "source": [
+    "The number \"1\" informs in which maximal cone of the fan of $\\mathbb{P}^2$ we perform the star subdivision. The string \"e\" defines the name for the new homogeneous coordinate of the toric variety. Here we have the following correspondance between ray generators and homogeneous variables:\n",
+    "\\begin{align}\n",
+    "x_1 &\\leftrightarrow [1,0] \\,\\\\\n",
+    "x_2 &\\leftrightarrow [0,1] \\,\\\\\n",
+    "x_3 &\\leftrightarrow [-1,-1] \\,.\n",
+    "\\end{align}\n",
+    "The blowup thus requires a star subdivision of the cone $C = \\mathrm{Span}_{\\mathbb{Z}_{\\geq 0}} \\left\\{ [1,0], [0,1]\\right\\}$. To this end, we first compute the sum of the generators of $C$. This is a new ray generator:\n",
+    "$$e \\leftrightarrow [1,1] \\,,$$\n",
+    "which we use to define the cones which maximally subdivide $C$, namely:\n",
+    "$$C_1 = \\mathrm{Span}_{\\mathbb{Z}_{\\geq 0}} \\left\\{ [1,0], [1,1]\\right\\} \\, , \\qquad C_2 = \\mathrm{Span}_{\\mathbb{Z}_{\\geq 0}} \\left\\{ [1,1], [0,1]\\right\\} \\, .$$\n",
+    "Let us see that this is indeed the case for the above computed toric space $BP^2$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "id": "36166499",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A polyhedral fan in ambient dimension 2"
+      ]
+     },
+     "execution_count": 85,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fan_of_BP2 = fan(BP2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 86,
+   "id": "b9b15ce5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4-element SubObjectIterator{RayVector{fmpq}}:\n",
+       " [0, 1]\n",
+       " [-1, -1]\n",
+       " [1, 0]\n",
+       " [1, 1]"
+      ]
+     },
+     "execution_count": 86,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rays(fan_of_BP2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c33a5c6e",
+   "metadata": {},
+   "source": [
+    "So we notice the new ray $[1,1]$. To find the new cones $C_1$ and $C_2$, we issue the following:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 87,
+   "id": "03632a99",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4-element Vector{SubObjectIterator{RayVector{fmpq}}}:\n",
+       " [[0, 1], [-1, -1]]\n",
+       " [[-1, -1], [1, 0]]\n",
+       " [[1, 0], [1, 1]]\n",
+       " [[0, 1], [1, 1]]"
+      ]
+     },
+     "execution_count": 87,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[rays(c) for c in maximal_cones(fan_of_BP2)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19ffe865",
+   "metadata": {},
+   "source": [
+    "So indeed, the last two cones are the expected new cones. The first two are the cones that exist for the fan of $\\mathbb{P}^2$ and were not changed.\n",
+    "\n",
+    "The variable $e$ we can see most prominently in the Cox ring:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "id": "74ada845",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Multivariate Polynomial Ring in x2, x3, x1, e over Rational Field graded by \n",
+       "  x2 -> [1 0]\n",
+       "  x3 -> [0 1]\n",
+       "  x1 -> [1 0]\n",
+       "  e -> [-1 1]"
+      ]
+     },
+     "execution_count": 88,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cox_ring(BP2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2652aab6",
+   "metadata": {},
+   "source": [
+    "It is instructive to look at the following alternative grading of the Cox ring (and we order the variables in ascending order):\n",
+    "$$\\begin{array}{ccc|c} x_1 & x_2 & x_3 & e \\\\ \\hline 1 & 1 & 1 & 0 \\\\ 1 & 1 & 0 & -1 \\end{array}$$\n",
+    "In the first line you notice the ordinary grading of the Cox ring of $\\mathbb{P}^2$. The second line corresonds to the toric blowup that has been conducted. The $-1$ for $e$ tells us that this is the homogeneous coordinate introduced to resemble the blowup $\\mathbb{P}^1$. The 1 for $x_1$ and $x_2$ tells us that it replaced the locus $\\{ x_1 = x_2 = 0\\}$ in $\\mathbb{P}^2$. In other words, in $BP^2$, $x_1$ and $x_2$ cannot vanish simultaneously:\n",
+    "$$\\{ [x_1 : x_2 : x_3 : e] \\in BP^2 | x_1 = x_2 = 0\\} = \\emptyset \\, .$$\n",
+    "Indeed, we can see this quite explicitly from consulting the Stanley-Reisner ideal:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
+   "id": "98458ccb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ideal(x2*x1, x3*e)"
+      ]
+     },
+     "execution_count": 89,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stanley_reisner_ideal(BP2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf5cf9ed",
+   "metadata": {},
+   "source": [
+    "We can also see that the locus $V(e) \\in BP^2$ is a $\\mathbb{P}^1$. Namely, from the Stanley-Reisner ideal we learn that $x_3$ and $e$ cannot vanish simultaneously. So $x_3 \\neq 0$ and we can rescale it to $1$. This only leaves $x_1$ and $x_2$. They must not vanish simultaneously ($x_1 x_2 \\in I_{\\text{SR}}( BP^2 )$) and enjoy the standard grading $(1,1)$."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b26c45b",
+   "metadata": {},
+   "source": [
+    "## 3.5 Cartesian products"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "649d7b9a",
+   "metadata": {},
+   "source": [
+    "It is also possible to compute Cartesian products of toric varieties. Here is an example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 92,
+   "id": "d2857411",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A normal toric variety"
+      ]
+     },
+     "execution_count": 92,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "product = P2 * F2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "id": "3a224cb4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Multivariate Polynomial Ring in 7 variables xx1, xx2, xx3, yt1, ..., yx2 over Rational Field graded by \n",
+       "  xx1 -> [1 0 0]\n",
+       "  xx2 -> [1 0 0]\n",
+       "  xx3 -> [1 0 0]\n",
+       "  yt1 -> [0 1 0]\n",
+       "  yx1 -> [0 0 1]\n",
+       "  yt2 -> [0 1 0]\n",
+       "  yx2 -> [0 2 1]"
+      ]
+     },
+     "execution_count": 93,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cox_ring(product)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76c4fa36",
+   "metadata": {},
+   "source": [
+    "Notice that the set of variables \"xx*\" correspond to the $\\mathbb{P}^2$ factor, and the remaining variables are the homogeneous coordinates of the Hirzebruch surface $\\mathbb{F}_2$."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e02bd35",
+   "metadata": {},
+   "source": [
+    "## 3.6 Triangulations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d3749867",
+   "metadata": {},
+   "source": [
+    "Triangulations of polytopes open an entire arena for creating families of toric varieties whose properties are often related to one-another in interesting ways. A prominent example along these lines is the Kreuzer-Skarke database. Another popular example is the conifold transition, which we now use to demonstrate triangulation functionality in OSCAR:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 94,
+   "id": "3058f5f6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A polyhedron in ambient dimension 3"
+      ]
+     },
+     "execution_count": 94,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "P = convex_hull([0 0 0; 0 0 1; 1 0 1; 1 1 1; 0 1 1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 95,
+   "id": "2e6c745e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2-element Vector{NormalToricVariety}:\n",
+       " A normal toric variety\n",
+       " A normal toric variety"
+      ]
+     },
+     "execution_count": 95,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    " (v1, v2) = NormalToricVarietiesFromStarTriangulations(P::Polyhedron)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "613b4fe6",
+   "metadata": {},
+   "source": [
+    "If desired, you can look at $P$ by invoking *Visualize(P)*. The polyhedron $P$ admits exactly two fine, regular, star triangulations. These were used to create the toric varieties $v_1$ and $v_2$. We now study these two varieties:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 96,
+   "id": "355ceab9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true"
+      ]
+     },
+     "execution_count": 96,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_smooth(v1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 97,
+   "id": "57442ac8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "false"
+      ]
+     },
+     "execution_count": 97,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_projective(v1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 98,
+   "id": "d184417e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 98,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dim(v1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 99,
+   "id": "69e68a1c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "false"
+      ]
+     },
+     "execution_count": 99,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_complete(v1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 100,
+   "id": "2cd0d131",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Multivariate Polynomial Ring in x1, x2, x3, x4 over Rational Field graded by \n",
+       "  x1 -> [1]\n",
+       "  x2 -> [-1]\n",
+       "  x3 -> [1]\n",
+       "  x4 -> [-1]"
+      ]
+     },
+     "execution_count": 100,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cox_ring(v1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 101,
+   "id": "c6acecd8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ideal(x2*x4)"
+      ]
+     },
+     "execution_count": 101,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stanley_reisner_ideal(v1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "333957a6",
+   "metadata": {},
+   "source": [
+    "If we repeat these line with $v_2$, then the only difference is:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 102,
+   "id": "56b8624e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ideal(x1*x3)"
+      ]
+     },
+     "execution_count": 102,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stanley_reisner_ideal(v2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "069877aa",
+   "metadata": {},
+   "source": [
+    "So in a sence, the transition from $v_1$ to $v_2$ means that the roles of ($x_2$, $x_4$) and ($x_1$, $x_3$) are exchanged. Indeed, the conifold transition means to first perform a deformation which shrinks an algebraic cycle to zero. This leads to a conifold singularity which is subsequently resolved by blowing up another algebraic cycle."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "05a3e827",
+   "metadata": {},
+   "source": [
+    "## 3.7 Benchmarking an involved triangulation computation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9edb57a6",
+   "metadata": {},
+   "source": [
+    "Triangulations are a topic that features prominently in applied mathematics, e.g. in string theory. The following code was used in a recent string theory publication (https://arxiv.org/abs/2205.00008):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 103,
+   "id": "60ef9e8f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "involved_triangulation (generic function with 1 method)"
+      ]
+     },
+     "execution_count": 103,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "function involved_triangulation()\n",
+    "    \n",
+    "    # (0) Define the polytope\n",
+    "    fac1 = convex_hull( [-1 -1 -1; 2 -1 -1; -1 2 -1]);\n",
+    "    fac2 = convex_hull( [-1 -1 -1; 2 -1 -1; -1 -1 5]);\n",
+    "    fac3 = convex_hull( [-1 -1 -1; -1 2 -1; -1 -1 5]);\n",
+    "    fac4 = convex_hull( [2 -1 -1; -1 2 -1; -1 -1 5]);\n",
+    "    fac = fac1;\n",
+    "    \n",
+    "    # (1) Set variable names of our choice\n",
+    "    vars_dict = Dict();\n",
+    "    vars_dict[matrix(ZZ,[-1 -1 -1])] = \"x0\";\n",
+    "    vars_dict[matrix(ZZ,[2 -1 -1])] = \"x1\";\n",
+    "    vars_dict[matrix(ZZ,[-1 2 -1])] = \"x2\";\n",
+    "    vars_dict[matrix(ZZ,[-1 -1 5])] = \"x3\";\n",
+    "    vars_dict[matrix(ZZ,[-1 -1 0])] = \"x4\";\n",
+    "    vars_dict[matrix(ZZ,[-1 -1 1])] = \"x5\";\n",
+    "    vars_dict[matrix(ZZ,[-1 -1 2])] = \"x6\";\n",
+    "    vars_dict[matrix(ZZ,[-1 -1 3])] = \"x7\";\n",
+    "    vars_dict[matrix(ZZ,[-1 -1 4])] = \"x8\";\n",
+    "    vars_dict[matrix(ZZ,[-1 0 -1])] = \"x9\";\n",
+    "    vars_dict[matrix(ZZ,[-1 0 0])] = \"x10\";\n",
+    "    vars_dict[matrix(ZZ,[-1 0 1])] = \"x11\";\n",
+    "    vars_dict[matrix(ZZ,[-1 0 2])] = \"x12\";\n",
+    "    vars_dict[matrix(ZZ,[-1 0 3])] = \"x13\";\n",
+    "    vars_dict[matrix(ZZ,[-1 1 -1])] = \"x14\";\n",
+    "    vars_dict[matrix(ZZ,[-1 1 0])] = \"x15\";\n",
+    "    vars_dict[matrix(ZZ,[-1 1 1])] = \"x16\";\n",
+    "    vars_dict[matrix(ZZ,[0 -1 -1])] = \"x17\";\n",
+    "    vars_dict[matrix(ZZ,[0 -1 0])] = \"x18\";\n",
+    "    vars_dict[matrix(ZZ,[0 -1 1])] = \"x19\";\n",
+    "    vars_dict[matrix(ZZ,[0 -1 2])] = \"x20\";\n",
+    "    vars_dict[matrix(ZZ,[0 -1 3])] = \"x21\";\n",
+    "    vars_dict[matrix(ZZ,[0 0 -1])] = \"x22\";\n",
+    "    vars_dict[matrix(ZZ,[0 0 1])] = \"x23\";\n",
+    "    vars_dict[matrix(ZZ,[0 1 -1])] = \"x24\";\n",
+    "    vars_dict[matrix(ZZ,[1 -1 -1])] = \"x25\";\n",
+    "    vars_dict[matrix(ZZ,[1 -1 0])] = \"x26\";\n",
+    "    vars_dict[matrix(ZZ,[1 -1 1])] = \"x27\";\n",
+    "    vars_dict[matrix(ZZ,[1 0 -1])] = \"x28\";\n",
+    "    \n",
+    "    #(2) Form point set to be triangulated\n",
+    "    points = lattice_points(fac);\n",
+    "    d = ambient_dim(fac)\n",
+    "    pts = vcat(zero_matrix(ZZ, 1, d), matrix(ZZ, transpose(reduce(hcat,points))));\n",
+    "    \n",
+    "    #(3) Triangulate\n",
+    "    trias = star_triangulations(pts; full=true, regular=true);\n",
+    "    trias = [[[c[k]-1 for k in 2:length(c)] for c in t] for t in trias];\n",
+    "    \n",
+    "    #(4) Compute rays of all toric varieties\n",
+    "    fan_rays = matrix(ZZ, points);\n",
+    "    \n",
+    "    #(5) Construct ring which contains all Stanley-Reisner ideals\n",
+    "    max_cones = IncidenceMatrix(vcat(trias[1]));\n",
+    "    pmfan = Polymake.fan.PolyhedralFan(RAYS=fan_rays, MAXIMAL_CONES=max_cones);\n",
+    "    variety = NormalToricVariety(PolyhedralFan{fmpq}(pmfan));\n",
+    "    my_vars = [vars_dict[fan_rays[i,:]] for i in 1:nrows(fan_rays)];\n",
+    "    set_coordinate_names(variety, my_vars);\n",
+    "    R = cox_ring(variety);\n",
+    "    \n",
+    "    #(6) Compute all ideals\n",
+    "    sr_ideals_julia = [];\n",
+    "    for n in 1:length(trias)\n",
+    "        id = stanley_reisner_ideal(R, SimplicialComplex(trias[n]));\n",
+    "        push!(sr_ideals_julia,id);\n",
+    "    end;\n",
+    "    \n",
+    "    #(7) Finall intersect all ideals\n",
+    "    return common_sr_ideal = reduce(intersect,sr_ideals_julia);\n",
+    "    \n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2dd7c40d",
+   "metadata": {},
+   "source": [
+    "In a nutshell, this code computes all fine regular star triangulations of the polyhedron *fac1*, computes the Stanley-Reisner of the associated toric varieties and then intersects these ideals. As such, it finds the intersection theory that is common to this family of toric varieties.\n",
+    "\n",
+    "The code for *fac1* and *fac4* will likely execute within a few seconds. For the polyhedrons *fac2* or *fac3*, the task is much more involved and will likely take a few minutes. This is why in the above code, we fixed the choice of polyhedron to *fac1*. Brave users may which to challenge their computer a bit by altering that choice to *fac2* or *fac3*. The computations should still complete on most private computers within a few minutes.\n",
+    "\n",
+    "To benchmark the execution time of the function*involved_triangulation*, and thus provide comparision to other computer systems, we can execute the following:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 104,
+   "id": "2ba11127",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  246.043 ms (358950 allocations: 13.92 MiB)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "ideal(x24*x1, x17*x1, x2*x1, x0*x1, x2*x28, x9*x28, x14*x25, x0*x25, x17*x24, x9*x2, x0*x2, x0*x14, x9*x14*x1, x0*x24*x28, x14*x17*x28, x9*x24*x25, x2*x17*x25, x22*x25*x28*x1, x14*x22*x28*x1, x9*x22*x25*x1, x22*x24*x25*x28, x17*x22*x25*x28, x14*x22*x24*x28, x0*x17*x22*x28, x2*x22*x24*x25, x9*x17*x22*x25, x14*x2*x22*x24, x9*x14*x22*x24, x0*x9*x22*x24, x14*x2*x17*x22, x9*x14*x17*x22, x0*x9*x17*x22)"
+      ]
+     },
+     "execution_count": 104,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "using BenchmarkTools\n",
+    "@btime involved_triangulation()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "507ee91f",
+   "metadata": {},
+   "source": [
+    "You might find it interesting to compare your executation time to the following result:\n",
+    "* Execution time: 246.043ms,\n",
+    "* 358874 allocations (13.92 MiB).\n",
+    "\n",
+    "This result was obtained on January 31, 2023 by runnning the OSCAR version 0.11.3-DEV (commit 12ca1087849c3f34fa69146afba648fa3aa0b934) on a TUXEDO InfinityBook Pro 14 v4 with Intel Core i7-Quad-Core, 32GB RAM and operating system Ubuntu 20.04.5 LTS."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4c37903",
+   "metadata": {},
+   "source": [
+    "## 3.8 Turning off input checks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7dece43",
+   "metadata": {},
+   "source": [
+    "OSCAR aims for a broad user audience. As such, input is usually checked for consistency. This comes at the expense of loosing a bit of performance and possibly modifying the input data (if needed), e.g. shuffling it. In the toric settings, such shufflings of e.g. the order of rays can be undesirable.\n",
+    "\n",
+    "It is possible to switch off such input checks when creating toric varieties. *However, it must be emphasized that then it is the user's responsibility to provide sane input.*\n",
+    "\n",
+    "As an example, the following lines are executed internally to create the del Pezzo surface $dP_3$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 105,
+   "id": "d2a40fcc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A normal toric variety"
+      ]
+     },
+     "execution_count": 105,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fan_rays = [1 0; 0 1; -1 -1; 1 1; 0 -1; -1 0]\n",
+    "cones = IncidenceMatrix([[1, 4], [2, 4], [1, 5], [5, 3], [2, 6], [6, 3]])\n",
+    "variety = NormalToricVariety(PolyhedralFan(fan_rays, cones; non_redundant = true))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56241ab3",
+   "metadata": {},
+   "source": [
+    "Notice the *non_redundant = true* entry in the constructor for *NormalToricVariety*. This switches off the input check by informing OSCAR that we (= the users) made user that there is no redundancy in the input. Use with care and only after you made sure that the input is indeed sane.\n",
+    "\n",
+    "To continue with the above example, we would like to see that this is indeed a del Pezzo surface. This can be seen directly from the fan - the three last rays correspond to star subdivision of the 3 maximal cones of $\\mathbb{P}^2$ - or by studying the properties of the variety in more detail. We opt for the latter and first assign suitable variable names:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 106,
+   "id": "06a0a031",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    " vars = [\"x1\", \"x2\", \"x3\", \"e1\", \"e2\", \"e3\"]\n",
+    " set_coordinate_names(variety, vars[1:6])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ebd16d50",
+   "metadata": {},
+   "source": [
+    "It is also convenient to make a (valid!) standard choice for the grading of the cox ring. Namely, this must be such that the grading matrix corresponds to the map from the character lattice to the torus invariant Weil divisor group. It is not too hard to verify that the following is a valid (and in fact arguably the standard choice):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 107,
+   "id": "ea12eede",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "weights = matrix(ZZ, [1 1 1 0; 1 1 0 1; 1 0 1 1; 0 -1 0 0; 0 0 -1 0; 0 0 0 -1])\n",
+    "set_attribute!(variety, :map_from_torusinvariant_weil_divisor_group_to_class_group, hom(torusinvariant_weil_divisor_group(variety), class_group(variety), weights))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "503fae45",
+   "metadata": {},
+   "source": [
+    "When executing *del_pezzo_surface(3)* more properties are set by OSCAR. But that put aside, the above are the internal steps of the constructor.\n",
+    "\n",
+    "With that said, the following should identify this space as the del Pezzo surface $dP_3$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 108,
+   "id": "676ade3c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Multivariate Polynomial Ring in 6 variables x1, x2, x3, e1, ..., e3 over Rational Field graded by \n",
+       "  x1 -> [1 1 1 0]\n",
+       "  x2 -> [1 1 0 1]\n",
+       "  x3 -> [1 0 1 1]\n",
+       "  e1 -> [0 -1 0 0]\n",
+       "  e2 -> [0 0 -1 0]\n",
+       "  e3 -> [0 0 0 -1]"
+      ]
+     },
+     "execution_count": 108,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cox_ring(variety)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 109,
+   "id": "8dc6087a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true"
+      ]
+     },
+     "execution_count": 109,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_smooth(variety)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 110,
+   "id": "38b14b68",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true"
+      ]
+     },
+     "execution_count": 110,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "is_projective(variety)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 111,
+   "id": "bb28b32e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5-element Vector{fmpz}:\n",
+       " 1\n",
+       " 0\n",
+       " 4\n",
+       " 0\n",
+       " 1"
+      ]
+     },
+     "execution_count": 111,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[betti_number(variety,i) for i in range(0,4)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 112,
+   "id": "ea340fdd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "GrpAb: Z^4"
+      ]
+     },
+     "execution_count": 112,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "picard_group(variety)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 113,
+   "id": "3a0716f1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "GrpAb: Z^6"
+      ]
+     },
+     "execution_count": 113,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "torusinvariant_weil_divisor_group(variety)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 114,
+   "id": "ea65ee31",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "GrpAb: Z^2"
+      ]
+     },
+     "execution_count": 114,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "character_lattice(variety)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b8a09dc",
+   "metadata": {},
+   "source": [
+    "# 4 Advanced topics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "034ecbc0",
+   "metadata": {},
+   "source": [
+    "## 4.1 Vanishing sets "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d31a88e",
+   "metadata": {},
+   "source": [
+    "For (smooth, complete) and (simplicial, projective) toric varieties, it is possible to find a unified description for all line bundles for which a certain cohomology class vanishes. This set is then referred to as a vanishing set.\n",
+    "\n",
+    "The first description of this approach can be found in appendix B of https://arxiv.org/pdf/1802.08860.pdf. The corresponding functionality is available in Oscar.\n",
+    "\n",
+    "We begin by demonstrating this for the projective space $\\mathbb{P}^2$, for which the vanishing sets are well-known. Namely:\n",
+    "\\begin{align}\n",
+    "V^0( \\mathbb{P}^2 ) &= \\{ \\mathcal{L} \\in \\mathrm{Pic}(\\mathbb{P}^2) | h^0(\\mathbb{P}^2, \\mathcal{L}) = 0\\} = \\{ \\mathcal{L} \\in \\mathrm{Pic}(\\mathbb{P}^2) | \\mathrm{deg}( \\mathcal{L} ) < 0 \\} \\, , \\\\\n",
+    "V^1( \\mathbb{P}^2 ) &= \\{ \\mathcal{L} \\in \\mathrm{Pic}(\\mathbb{P}^2) | h^1(\\mathbb{P}^2, \\mathcal{L}) = 0\\} = \\mathrm{Pic}(\\mathbb{P}^2) \\, , \\\\\n",
+    "V^2( \\mathbb{P}^2 ) &= \\{ \\mathcal{L} \\in \\mathrm{Pic}(\\mathbb{P}^2) | h^2(\\mathbb{P}^2, \\mathcal{L}) = 0\\} = \\{ \\mathcal{L} \\in \\mathrm{Pic}(\\mathbb{P}^2) | \\mathrm{deg}( \\mathcal{L} ) > -2 \\}\\, .\n",
+    "\\end{align}\n",
+    "Let us recompoute this with OSCAR:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 117,
+   "id": "fac1fd5d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3-element Vector{ToricVanishingSet}:\n",
+       " A toric vanishing set for cohomology index 0\n",
+       " A toric vanishing set for cohomology index 1\n",
+       " A toric vanishing set for cohomology index 2"
+      ]
+     },
+     "execution_count": 117,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "vs = vanishing_sets(P2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 118,
+   "id": "94fafa02",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1-element Vector{Polyhedron{fmpq}}:\n",
+       " A polyhedron in ambient dimension 1"
+      ]
+     },
+     "execution_count": 118,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "polyhedra(vs[1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 119,
+   "id": "e68b153c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A polyhedron in ambient dimension 1"
+      ]
+     },
+     "execution_count": 119,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "p0 = polyhedra(vs[1])[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 120,
+   "id": "00fe619e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1-element SubObjectIterator{PointVector{fmpq}}:\n",
+       " [0]"
+      ]
+     },
+     "execution_count": 120,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "vertices(p0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 121,
+   "id": "e5601b17",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1-element SubObjectIterator{RayVector{fmpq}}:\n",
+       " [1]"
+      ]
+     },
+     "execution_count": 121,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rays(p0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c2b2a89",
+   "metadata": {},
+   "source": [
+    "We are thus looking at $C = \\mathrm{Span}_{\\mathbb{Z}_{\\geq 0}}(1) \\}$. This cone is a subset of $\\mathrm{Pic}( \\mathbb{P}^2)$ and the vanishing set is its complement, that is:\n",
+    "$$V^0( \\mathbb{P}^2 ) = \\{ \\mathcal{L} \\in \\mathrm{Pic}(\\mathbb{P}^2) | h^0(\\mathbb{P}^2, \\mathcal{L}) = 0\\} = \\{ \\mathcal{L} \\in \\mathrm{Pic}(\\mathbb{P}^2) | \\mathcal{L} ) \\notin C \\} \\, .$$\n",
+    "It is readily verified that this indeed matches the above expectation.\n",
+    "\n",
+    "Recall that $V^1( \\mathbb{P}^2 ) = \\mathrm{Pic}(\\mathbb{P}^2)$. This we can see quickly:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 124,
+   "id": "23379a97",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Polyhedron{fmpq}[]"
+      ]
+     },
+     "execution_count": 124,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "polyhedra(vs[2])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dab23dd6",
+   "metadata": {},
+   "source": [
+    "This list of polyhedra is empty. In other words, the vanishing set is the completement of the empty set in $\\mathrm{Pic}( \\mathbb{P}^2 )$, which is nothing but the entire Picard group.\n",
+    "\n",
+    "Let us now look at the vanishing set for $h^2$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 123,
+   "id": "35435687",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1-element Vector{Polyhedron{fmpq}}:\n",
+       " A polyhedron in ambient dimension 1"
+      ]
+     },
+     "execution_count": 123,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "polyhedra(vs[3])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 259,
+   "id": "826cb0db",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A polyhedron in ambient dimension 1"
+      ]
+     },
+     "execution_count": 259,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "p3 = polyhedra(vs[3])[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 260,
+   "id": "7654fa72",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1-element SubObjectIterator{PointVector{fmpq}}:\n",
+       " [-3]"
+      ]
+     },
+     "execution_count": 260,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "vertices(p3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 261,
+   "id": "7fa64721",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1-element SubObjectIterator{RayVector{fmpq}}:\n",
+       " [-1]"
+      ]
+     },
+     "execution_count": 261,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rays(p3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8a9d175",
+   "metadata": {},
+   "source": [
+    "We are thus looking at $P3 = \\{-3\\} + \\mathrm{Span}_{\\mathbb{Z}_{\\geq 0}}(-1) \\}$ and its complement is $V^2( \\mathbb{P}^2 )$ just as expected.\n",
+    "\n",
+    "Recall that we constructed a line bundle $\\mathcal{L}$ on $\\mathbb{P}^2$ above:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 264,
+   "id": "8bdbe371",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A toric line bundle on a normal toric variety"
+      ]
+     },
+     "execution_count": 264,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "L = ToricLineBundle(P2, [1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "741417ca",
+   "metadata": {},
+   "source": [
+    "Its cohomologies are:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 265,
+   "id": "59c8bc52",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3-element Vector{fmpz}:\n",
+       " 3\n",
+       " 0\n",
+       " 0"
+      ]
+     },
+     "execution_count": 265,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "all_cohomologies(L)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6dd40d08",
+   "metadata": {},
+   "source": [
+    "So $L$ is not $V^0( \\mathbb{P}^2 )$ but in $V^1( \\mathbb{P}^2 )$ and $V^2( \\mathbb{P}^2 )$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 266,
+   "id": "a6b48579",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "false"
+      ]
+     },
+     "execution_count": 266,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "contains(vs[1],L)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 267,
+   "id": "da686378",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true"
+      ]
+     },
+     "execution_count": 267,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "contains(vs[3],L)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "643f4604",
+   "metadata": {},
+   "source": [
+    "## 4.2 Intersection theory"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b882d96",
+   "metadata": {},
+   "source": [
+    "Intersection theory for toric varieties is well-understood and the Chow ring under good control. For a good example, let us consider the del Pezzo surface $dP_2$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 272,
+   "id": "50fb2c0a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A normal, non-affine, smooth, projective, gorenstein, fano, 2-dimensional toric variety without torusfactor"
+      ]
+     },
+     "execution_count": 272,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dP2 = del_pezzo_surface(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d866b1c",
+   "metadata": {},
+   "source": [
+    "Recall that this constructors invokes standard names for the homogeneous coordinates. This we can see upon execution of the Cox ring:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 274,
+   "id": "8c404f51",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Multivariate Polynomial Ring in x1, x2, x3, e1, e2 over Rational Field graded by \n",
+       "  x1 -> [1 1 1]\n",
+       "  x2 -> [1 1 0]\n",
+       "  x3 -> [1 0 1]\n",
+       "  e1 -> [0 -1 0]\n",
+       "  e2 -> [0 0 -1]"
+      ]
+     },
+     "execution_count": 274,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cox_ring(dP2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e019841a",
+   "metadata": {},
+   "source": [
+    "Closed algebraic subvarieties are one to one to homogeneous ideals in this ring. An algebraic cycle is a formal linear sum of such closed subvarieties. Modulo rational equivalence, the algebraic cycles then furnish the Chow ring. We can compute this ring as follows in OSCAR:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 275,
+   "id": "da0d77a6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Quotient of Multivariate Polynomial Ring in x1, x2, x3, e1, e2 over Rational Field by ideal(x1 - x3 + e1, x2 - x3 + e1 - e2, x1*x2, x1*x3, e1*e2, x2*e2, x3*e1)"
+      ]
+     },
+     "execution_count": 275,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chow_ring(dP2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "39ab0ff2",
+   "metadata": {},
+   "source": [
+    "There are several ways to create a rational equivalence class of an algebraic cycle. Here is one way to create such an object:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 273,
+   "id": "9a8a9e87",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A rational equivalence class on a normal toric variety represented by 6V(x3)+V(e1)+7V(e2)"
+      ]
+     },
+     "execution_count": 273,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "d = ToricDivisor(dP2, [1, 2, 3, 4, 5])\n",
+    "ac = RationalEquivalenceClass(d)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30344208",
+   "metadata": {},
+   "source": [
+    "So $ac$ is represented by an algebraic cycle which in turn is given by a formal linear sum of the closed subvarieties $V(x_3)$, $V(e_1)$ and $V(e_2)$, namely $6 V(x_3) + 1 V( e_1 ) + 7 V( e_2 )$.\n",
+    "\n",
+    "It is key that intersections of such rational equivalence classes can be computed. Indeed, this is possible in OSCAR:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 276,
+   "id": "85c9c7e1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A rational equivalence class on a normal toric variety represented by 34V(x2,x3)"
+      ]
+     },
+     "execution_count": 276,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ac * ac"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f2eae9e",
+   "metadata": {},
+   "source": [
+    "If we only care about topological intersection numbers, then the intersection form suffices:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 278,
+   "id": "bfc4c884",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Dict{MPolyElem, fmpq} with 15 entries:\n",
+       "  x1*x3 => 0\n",
+       "  x3*e2 => 1\n",
+       "  x1^2  => -1\n",
+       "  x1*e1 => 1\n",
+       "  e2^2  => -1\n",
+       "  x3^2  => 0\n",
+       "  x2*x3 => 1\n",
+       "  e1*e2 => 0\n",
+       "  x2*e1 => 1\n",
+       "  x1*e2 => 1\n",
+       "  x2^2  => 0\n",
+       "  e1^2  => -1\n",
+       "  x3*e1 => 0\n",
+       "  x1*x2 => 0\n",
+       "  x2*e2 => 0"
+      ]
+     },
+     "execution_count": 278,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "intersection_form(dP2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1266dbbe",
+   "metadata": {},
+   "source": [
+    "Note that this is obtained upon normalization with the volume form:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 280,
+   "id": "485e2919",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "A cohomology class on a normal toric variety given by -e2^2"
+      ]
+     },
+     "execution_count": 280,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "volume_form(dP2)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 1.7.2",
+   "language": "julia",
+   "name": "julia-1.7"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "1.7.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR should:
* Add new entry `Tutorials` to the sidebar.
* Fill it with the content of `tutorials.md`.
* Add a link to the jupyter notebook, which provides a (first) tutorial on toric geometry in OSCAR.

(Sadly, I could again not conduct a local test due to an issue with my local system/installation. @fingolfin could you please inspect my changes carefully? Thank you very much.)

cc @wdecker @fieker