### PR TITLE
Instructions for notebooks in Windows Subsystem

### DIFF
--- a/install.md
+++ b/install.md
@@ -209,3 +209,8 @@ the [trouble shooting page](https://julialang.github.io/IJulia.jl/stable/manual/
 If you try to open an existing notebook (stored in a ".ipynb" file), it might refer to an
 older Julia version, resulting in a "Kernel error"; the solution is then to select
 a different kernel from the menu.
+
+If you are using OSCAR in the Windows Subsystem for Linux, you will require a browser 
+in your subsystem. This can be a probem as the default subsystem is Ubuntu and Ubuntu 
+installs browsers via snap which is disabled for subsystems. To circumvent this problem, 
+please see [how to install browsers via deb](https://www.omgubuntu.co.uk/2022/04/how-to-install-firefox-deb-apt-ubuntu-22-04).


### PR DESCRIPTION
By default Ubuntu installs browsers via snap which is disabled in Windows Subsystems. Worse, the Windows Subsystem will install the browser via snap, but starting a notebook from Julia will do nothing (not even return an error).

I added instructions on how to install a browser in the Windows Subsystem for Linux as a deb package. The method worked for me, let me know if there is a better solution.