### PR TITLE
Change paths to tutorials

### DIFF
--- a/tutorials.md
+++ b/tutorials.md
@@ -5,7 +5,7 @@ title: Tutorials
 
 Here is a list of tutorials (all [Jupyter notebooks](https://jupyter.org/)) on selected topics:
 
-1. [Commutative Algebra](https://github.com/oscar-system/oscar-website/blob/gh-pages/tutorials/CommutativeAlgebraInOSCAR.ipynb) (by Luca Remke, last updated on June 6, 2023).
+1. [Commutative Algebra](https://github.com/oscar-system/oscar-website/blob/gh-pages/tutorials/CommutativeAlgebraInOSCAR.ipynb) (by Luca Remke, last updated on June 21, 2023).
 2. [Polyhedral Geometry](https://github.com/oscar-system/oscar-website/blob/gh-pages/tutorials/PolyhedralGeometryInOSCAR.ipynb) (by Luca Remke, last updated on June 6, 2023).
 3. [Toric Geometry](https://github.com/oscar-system/oscar-website/blob/gh-pages/tutorials/ToricGeometryInOSCAR1.ipynb) (by Luca Remke, last updated on June 6, 2023).
 4. [Advanced topics on toric geometry](https://github.com/oscar-system/oscar-website/blob/gh-pages/tutorials/ToricGeometryInOSCAR.ipynb) (by [Martin Bies](https://martinbies.github.io/), last updated on March 7, 2023).

--- a/tutorials.md
+++ b/tutorials.md
@@ -5,12 +5,12 @@ title: Tutorials
 
 Here is a list of tutorials (all [Jupyter notebooks](https://jupyter.org/)) on selected topics:
 
-1. [Commutative Algebra](https://nbviewer.jupyter.org/github/oscar-system/oscar-website/blob/gh-pages/tutorials/CommutativeAlgebraInOSCAR.ipynb) (by Luca Remke, last updated on June 6, 2023).
-2. [Polyhedral Geometry](https://nbviewer.jupyter.org/github/oscar-system/oscar-website/blob/gh-pages/tutorials/PolyhedralGeometryInOSCAR.ipynb) (by Luca Remke, last updated on June 6, 2023).
-3. [Toric Geometry](https://nbviewer.jupyter.org/github/oscar-system/oscar-website/blob/gh-pages/tutorials/ToricGeometryInOSCAR1.ipynb) (by Luca Remke, last updated on June 6, 2023).
-4. [Advanced topics on toric geometry](https://nbviewer.jupyter.org/github/oscar-system/oscar-website/blob/gh-pages/tutorials/ToricGeometryInOSCAR.ipynb) (by [Martin Bies](https://martinbies.github.io/), last updated on March 7, 2023).
-5. [Quadratic lattices](https://nbviewer.org/github/thofma/HeckeTutorials.jl/blob/master/quadratic_forms.ipynb) (by Tommy Hofmann, last updated on June 1, 2023).
+1. [Commutative Algebra](https://github.com/oscar-system/oscar-website/blob/gh-pages/tutorials/CommutativeAlgebraInOSCAR.ipynb) (by Luca Remke, last updated on June 6, 2023).
+2. [Polyhedral Geometry](https://github.com/oscar-system/oscar-website/blob/gh-pages/tutorials/PolyhedralGeometryInOSCAR.ipynb) (by Luca Remke, last updated on June 6, 2023).
+3. [Toric Geometry](https://github.com/oscar-system/oscar-website/blob/gh-pages/tutorials/ToricGeometryInOSCAR1.ipynb) (by Luca Remke, last updated on June 6, 2023).
+4. [Advanced topics on toric geometry](https://github.com/oscar-system/oscar-website/blob/gh-pages/tutorials/ToricGeometryInOSCAR.ipynb) (by [Martin Bies](https://martinbies.github.io/), last updated on March 7, 2023).
+5. [Quadratic lattices](https://github.com/thofma/HeckeTutorials.jl/blob/master/quadratic_forms.ipynb) (by Tommy Hofmann, last updated on June 1, 2023).
 
 Here is a list of tutorials (all [Jupyter notebooks](https://jupyter.org/)) on *experimental* topics in OSCAR:
 
-1. [FTheoryTools](https://nbviewer.jupyter.org/github/oscar-system/oscar-website/blob/gh-pages/tutorials/FTheoryToolsInOSCAR.ipynb) (by [Andrew P. Turner](https://apturner.net/), last updated on May 4, 2023).
+1. [FTheoryTools](https://github.com/oscar-system/oscar-website/blob/gh-pages/tutorials/FTheoryToolsInOSCAR.ipynb) (by [Andrew P. Turner](https://apturner.net/), last updated on May 4, 2023).


### PR DESCRIPTION
We are currently suffering from https://github.com/jupyter/nbviewer/issues/972, i.e. `Nbviewer` does not show the updated `jupyter` notebooks. This has been an open issue for years. As far as I can tell from the discussion, the only known resolution is that this issue resolves by itself, but after an unpredictable amount of time.

As suggested by @fingolfin, this PR changes the paths of the tutorials to the preview on github.