### PR TITLE
Add talks and a poster of recent conferences

### DIFF
--- a/talks.html
+++ b/talks.html
@@ -2,6 +2,22 @@
 layout: page
 title: Talks
 talks:
+    - title: "FTheoryTools: A computer tool for singular elliptic fibrations"
+      author: Martin Bies
+      date: "2023-07-12"
+      conference: String Math 2023
+      conference_url: https://stringmath2023.sciencesconf.org/
+      location: "Melbourne, Australia"
+      pdf_url: https://rtca2023.github.io/pages_Lyon/DocM3/Fieker.pdf
+
+  - title: "FTheoryTools: A computational tool for analysis of singular elliptic fibrations"
+      author: Andrew Turner
+      date: "2023-07-04"
+      conference: String Pheno '23
+      conference_url: https://indico.cern.ch/event/1270020/
+      location: "Daejeon, South Korea"
+      pdf_url: https://indico.cern.ch/event/1270020/contributions/5472895/attachments/2684853/4658073/11%20Turner.pdf
+
     - title: "Number Theory in Oscar: Class Groups, Class Fields and Beyond"
       author: Claus Fieker
       date: "2023-06-28"
@@ -16,6 +32,22 @@ talks:
       conference: Mathematical Software and High Performance Algebraic Computing
       conference_url: https://rtca2023.github.io/pages_Lyon/m3.html
       location: "Lyon, France"
+
+    - title: "F-theory Tools: String theory applications of OSCAR"
+      author: Martin Bies
+      date: "2023-05-31"
+      conference: Computeralgebra-Tagung 2023
+      conference_url: https://konferenz.uni-hannover.de/event/83/
+      location: "Hannover, Germany"
+      pdf_url: https://martinbies.github.io/PresentationCAT2023MartinBies.pdf
+
+    - title: "F-Theory and Singular Elliptic Fibrations"
+      author: Martin Bies
+      date: "2023-05-16"
+      conference: Oberseminar Algebraische Geometry, Universitaet des Saarlandes
+      conference_url: https://www.uni-saarland.de/lehrstuhl/lazic/oberseminar-algebraische-geometrie.html
+      location: "Saarbruecken, Germany"
+      pdf_url: https://martinbies.github.io/TalkSBMay2023.pdf
 
     - title: "The OSCAR Computer Algebra System"
       author: Max Horn


### PR DESCRIPTION
This PR adds talks and posters from recent conferences, on which FTheoryTools was presented.

cc @fingolfin @fieker @wdecker @micjoswig 

