### PR TITLE
Get tutorial's "modified date" at build time automatically

### DIFF
--- a/_data/examples.yml
+++ b/_data/examples.yml
@@ -7,7 +7,7 @@
   author: John Abbott, Martin Bies, Luca Remke, Hans Schönemann
   thumbnail: CommutativeAlgebra.png
   language: julia
-  date: March 28, 2024
+  date: January 1, 1970
 
 - title: Polyhedral Geometry
   repository: HereAround/MartinsOscarTutorials.jl
@@ -16,7 +16,7 @@
   author: Martin Bies, Luca Remke
   thumbnail: PolyhedralGeometry.png
   language: julia
-  date: April 26, 2024
+  date: January 1, 1970
 
 - title: Toric geometry
   repository: HereAround/MartinsOscarTutorials.jl
@@ -25,7 +25,7 @@
   author: Martin Bies, Luca Remke
   thumbnail: ToricGeometry.png
   language: julia
-  date: March 28, 2024
+  date: January 1, 1970
 
 - title: F-Theory Tools
   repository: HereAround/MartinsOscarTutorials.jl
@@ -34,7 +34,7 @@
   author: Martin Bies, Andrew P. Turner
   thumbnail: FTheoryTools.png
   language: julia
-  date: April 3, 2024
+  date: January 1, 1970
 
 
 
@@ -48,7 +48,7 @@
   author: Tommy Hofmann
   thumbnail: NumberTheory.png
   language: julia
-  date: January 26, 2024
+  date: January 1, 1970
 
 
 
@@ -62,7 +62,7 @@
   author: Thomas Breuer
   thumbnail: GroupTheory.png
   language: julia
-  date: April 3, 2024
+  date: January 1, 1970
 
 - title: "Analyzing Rubik's Cube"
   repository: oscar-system/OSCARBinder
@@ -71,7 +71,7 @@
   author: Martin Schönert (translated to OSCAR by Thomas Breuer)
   thumbnail: GroupTheory.png
   language: julia
-  date: April 3, 2024
+  date: January 1, 1970
 
 - title: "Introduction to Number Fields: Towers"
   repository: oscar-system/OSCARBinder
@@ -80,7 +80,7 @@
   author: Claus Fieker
   thumbnail: NumberTheory.png
   language: julia
-  date: April 4, 2024
+  date: January 1, 1970
 
 - title: "Perfect central extensions of PSL(3,4) in the Monster group"
   repository: oscar-system/OSCARBinder
@@ -89,7 +89,7 @@
   author: Thomas Breuer
   thumbnail: GroupTheory.png
   language: julia
-  date: April 12, 2024
+  date: January 1, 1970
 
 - title: "Computations with Binomial Ideals"
   repository: oscar-system/OSCARBinder
@@ -98,7 +98,7 @@
   author: Wolfram Decker, Clara Petroll
   thumbnail: CommutativeAlgebra.png
   language: julia
-  date: May 15, 2024
+  date: January 1, 1970
 
 
 #- title: "Homology of VR complexes"

--- a/_includes/tutorial.html
+++ b/_includes/tutorial.html
@@ -71,9 +71,9 @@ the example, powered by <a href="https://mybinder.org">mybinder</a>.
 
 <div class="gallery_example_cards">
   {%- if page.main -%}
-  {%-     assign someexamples = site.data.examples_with_updated_date -%}
+  {%-     assign someexamples = site.data.with_updated_last_modified -%}
   {%- else -%}
-  {%-     assign someexamples = site.data.examples_with_updated_date | where:"thumbnail",page.component -%}
+  {%-     assign someexamples = site.data.with_updated_last_modified | where:"thumbnail",page.component -%}
   {%- endif -%}
   {%- for post in someexamples  -%}
 
@@ -101,9 +101,9 @@ the example, powered by <a href="https://mybinder.org">mybinder</a>.
 <div class="borked">
 <div class="gallery_example_cards">
   {%- if page.main -%}
-  {%-     assign someexamples = site.data.examples_with_updated_date -%}
+  {%-     assign someexamples = site.data.with_updated_last_modified -%}
   {%- else -%}
-  {%-     assign someexamples = site.data.examples_with_updated_date | where:"thumbnail",page.component -%}
+  {%-     assign someexamples = site.data.with_updated_last_modified | where:"thumbnail",page.component -%}
   {%- endif -%}
   {%- for post in someexamples  -%}
   <div class="item_example_card {{site.data.examples_status[post.filename]}}">

--- a/_includes/tutorial.html
+++ b/_includes/tutorial.html
@@ -71,9 +71,9 @@ the example, powered by <a href="https://mybinder.org">mybinder</a>.
 
 <div class="gallery_example_cards">
   {%- if page.main -%}
-  {%-     assign someexamples = site.data.examples -%}
+  {%-     assign someexamples = site.data.examples_with_updated_date -%}
   {%- else -%}
-  {%-     assign someexamples = site.data.examples | where:"thumbnail",page.component -%}
+  {%-     assign someexamples = site.data.examples_with_updated_date | where:"thumbnail",page.component -%}
   {%- endif -%}
   {%- for post in someexamples  -%}
 
@@ -101,9 +101,9 @@ the example, powered by <a href="https://mybinder.org">mybinder</a>.
 <div class="borked">
 <div class="gallery_example_cards">
   {%- if page.main -%}
-  {%-     assign someexamples = site.data.examples -%}
+  {%-     assign someexamples = site.data.examples_with_updated_date -%}
   {%- else -%}
-  {%-     assign someexamples = site.data.examples | where:"thumbnail",page.component -%}
+  {%-     assign someexamples = site.data.examples_with_updated_date | where:"thumbnail",page.component -%}
   {%- endif -%}
   {%- for post in someexamples  -%}
   <div class="item_example_card {{site.data.examples_status[post.filename]}}">

--- a/etc/update-dates.py
+++ b/etc/update-dates.py
@@ -1,0 +1,35 @@
+import json
+import yaml
+import requests
+
+from datetime import datetime
+
+ogfile = yaml.safe_load(open("../_data/examples.yml"))
+
+for i in range(len(ogfile)):
+    #assemble URL
+    repo = f"{ogfile[i]['repository']}"
+    filepath = f"{ogfile[i]['filename']}.ipynb"
+    url = f'https://api.github.com/repos/{repo}/commits?path={filepath}'
+
+    try:
+        #make request
+        #unauth API is rate limited at 60 per hour
+        #this should be okay for running script once per hour (we have less than 60 tutorials)
+        #auth API usage has limit of 5,000 requests per hour.
+        r = requests.get(url)
+        if r.status_code != 200:
+            raise ValueError(f"Reponse must have code 200, we got {r.status_code}")
+        r = json.loads(r.content)
+    except Exception as e:
+        print(e)
+        print(f"Got an error {e}.\nContinuing without updating time for {ogfile[i]['filename']}...")
+        continue
+
+    #update times
+    dt = datetime.strptime(r[0]['commit']['author']['date'], "%Y-%m-%dT%H:%M:%SZ")
+    d = dt.date().strftime("%B %d, %Y")
+    ogfile[i]['date'] = d
+
+with open('../_data/examples_with_updated_dates.yml', 'w') as outfile:
+    outfile.write(yaml.dump(ogfile))

--- a/etc/update-dates.py
+++ b/etc/update-dates.py
@@ -31,5 +31,5 @@ for i in range(len(ogfile)):
     d = dt.date().strftime("%B %d, %Y")
     ogfile[i]['date'] = d
 
-with open('../_data/examples_with_updated_dates.yml', 'w') as outfile:
+with open('../_data/examples_with_updated_last_modified.yml', 'w') as outfile:
     outfile.write(yaml.dump(ogfile))

--- a/etc/update.sh
+++ b/etc/update.sh
@@ -14,7 +14,10 @@ cat /srv/www/www-mathe-oscar/data/webhook.secret >> .htaccess
 bundle config set --local path 'vendor/bundle'
 bundle install
 
-# run jekyll
+# get tutorial status
 statusurl=$(curl -SsL --retry 5 "https://api.github.com/repos/oscar-system/TutorialTesterforOscar/actions/workflows/CI.yml/runs?per_page=1" | jq  '.workflow_runs[0].jobs_url' | sed 's/"//g')
 curl -SsL --retry 5 $statusurl | jq '.["jobs"][1:] | .[] | .name+":"+.conclusion' | sed 's/^.*\s.*\s.*\s//' | sed 's/):/: /' | sed s'/"$//' > _data/examples_status.yml
+# get tutorial last modified dates
+python update-dates.py
+# run jekyll
 bundle exec jekyll build --config _config.yml,_config_production.yml -d /srv/www/www-mathe-oscar/data/http


### PR DESCRIPTION
I have tested the python script, but I have not tried building the site on my workstation (ruby/bundle/gem/jekyll doesn't want to run at the moment, apparently).

Can you try this out @HereAround  ?

I've changed all the original dates to 1 January 1970 just to double check that the changes work as intended, we can revert that to something more sensible once we know for sure that `jekyll serve` still serves what we want.

Fixes #329 