### PR TITLE
Fix Tutorial filter for responsiveness

### DIFF
--- a/_data/examples_components.yml
+++ b/_data/examples_components.yml
@@ -1,12 +1,12 @@
 - logo: FTheoryTools.png
-  name: FTheoryTools
+  name: FTheory Tools
 - logo: GroupTheory.png
-  name: GroupTheory
+  name: Group Theory
 - logo: NumberTheory.png
-  name: NumberTheory
+  name: Number Theory
 - logo: PolyhedralGeometry.png
-  name: PolyhedralGeometry
+  name: Polyhedral Geometry
 - logo: CommutativeAlgebra.png
-  name: CommutativeAlgebra
+  name: Commutative Algebra
 - logo: ToricGeometry.png
-  name: ToricGeometry
+  name: Toric Geometry

--- a/_includes/tutorial.html
+++ b/_includes/tutorial.html
@@ -38,29 +38,27 @@ Alternatively, you can inspect the jupyter notebook directly on <a href="https:/
 <br/>
 Click on one of the links below to filter notebooks (and re-click to disable filtering).
 
-  <table>
-    <tr>
+<div class="example_column" style="padding: 0;display: flex; flex-wrap: wrap; border:1px solid #e5e5e5; margin-bottom: 80px;">
   {%- for component in site.data.examples_components -%}
-  {%- assign component_url = "/tutorials/" | append: component.name | append: "/" %}
-  <td class="example_column">
-    <a style="display: block; "
+  {%- assign component_url = "/tutorials/" | append: component.name | replace: " ", "" | append: "/" %}
+  <div style="width:calc(100%/4);background-color: #f9f9f9; border: inherit;">
+    <a style="display: block; text-align: center;"
        {% if page.url == component_url %}
            href="{{ site.baseurl }}/tutorials/"
-           style="font-weight: bold;"
+           style="display: block; text-align: center; font-weight: bold;"
        {% else %}
-           href="{{ site.baseurl }}/tutorials/{{ component.name }}"
+           href="{{ site.baseurl }}/{{component_url}}"
        {% endif %}
        >
       <img class="item_example-image-link"
            src="{{ site.baseurl }}/public/thumbnails/{{ component.logo }}">
-      <div>
+      <div style="word-break: break-word;">
         {{ component.name }}
       </div>
     </a>
-  </td>
+  </div>
   {%- endfor -%}
-</tr>
-</table>
+</div>
 
 <!--
 <br/>

--- a/_includes/tutorial.html
+++ b/_includes/tutorial.html
@@ -38,10 +38,10 @@ Alternatively, you can inspect the jupyter notebook directly on <a href="https:/
 <br/>
 Click on one of the links below to filter notebooks (and re-click to disable filtering).
 
-<div class="example_column" style="padding: 0;display: flex; flex-wrap: wrap; border:1px solid #e5e5e5; margin-bottom: 80px;">
+<div class="example_box">
   {%- for component in site.data.examples_components -%}
   {%- assign component_url = "/tutorials/" | append: component.name | replace: " ", "" | append: "/" %}
-  <div style="width:calc(100%/4);background-color: #f9f9f9; border: inherit;">
+  <div class="example">
     <a style="display: block; text-align: center;"
        {% if page.url == component_url %}
            href="{{ site.baseurl }}/tutorials/"

--- a/_includes/tutorial.html
+++ b/_includes/tutorial.html
@@ -45,7 +45,7 @@ Click on one of the links below to filter notebooks (and re-click to disable fil
     <a style="display: block; text-align: center;"
        {% if page.url == component_url %}
            href="{{ site.baseurl }}/tutorials/"
-           style="display: block; text-align: center; font-weight: bold;"
+           style="font-weight: bold;"
        {% else %}
            href="{{ site.baseurl }}/{{component_url}}"
        {% endif %}

--- a/_sass/hyde.scss
+++ b/_sass/hyde.scss
@@ -337,15 +337,18 @@ a.sidebar-nav-item:focus {
     display: inline-block; /* for centering */
 }
 
-/* Three image containers (use 25% for four, and 50% for two, etc) */
-.example_column {
-  float: left;
-  padding: 13px;
+.example_box {
+  display: flex;
+  flex-wrap: wrap;
+  border: 1px solid #e5e5e5;
   text-align: center;
 }
 
-.example_row {
-    margin-bottom: 5%;
+/* Four image containers (use 25% for four, and 50% for two, etc) */
+.example {
+    width: calc(100%/4);
+    background-color: #f9f9f9;
+    border: inherit;
 }
 
 /* Clear floats after image containers */

--- a/_sass/hyde.scss
+++ b/_sass/hyde.scss
@@ -342,6 +342,7 @@ a.sidebar-nav-item:focus {
   flex-wrap: wrap;
   border: 1px solid #e5e5e5;
   text-align: center;
+  margin-bottom: 5%;
 }
 
 /* Four image containers (use 25% for four, and 50% for two, etc) */


### PR DESCRIPTION
Fixes the tutorial filter to behave better in narrow screens: make the words break, and equalize the heights.

I have replaced the HTML table with a flexbox div, and transferred the styles over (the table would either keep the same heights, or break the text, but not both for whatever reason).

Here's a "side by side" of flexbox (top) v/s table (bottom).

![image](https://github.com/oscar-system/oscar-website/assets/7453256/3d4567a0-9e31-4136-ac6d-39661e9551fd)

Fixes #338 , hopefull.

cc @HereAround 