### PR TITLE
baseurl is prepended to path when running the relative_url filter

### DIFF
--- a/_config_production.yml
+++ b/_config_production.yml
@@ -1,2 +1,2 @@
 url:              'https://www.oscar-system.org'
-baseurl:          'https://www.oscar-system.org'
+baseurl:          ''


### PR DESCRIPTION
Should fix the broken links in meeting pages mentioned in #346 

cc @HereAround 