### PR TITLE
Create upcoming events section automatically.

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -5,7 +5,7 @@
   website: https://polymake.org/doku.php/workshops/lean_workshop1224
 
 - title: Computational Algebraic Geometry Workshop
-  end-date: "2024-11-18"
+  end-date: "2024-11-22"
   date: 18 - 22 Nov, 2024
   location: Durham University
   website: https://sites.google.com/view/durhamcompalggeom/home

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,0 +1,17 @@
+- title: LEAN meets MaRDI and OSCAR
+  end-date: "2024-12-05"
+  date: 5 - 6 Dec, 2024
+  location: TU Berlin
+  website: https://polymake.org/doku.php/workshops/lean_workshop1224
+
+- title: Computational Algebraic Geometry Workshop
+  end-date: "2024-11-18"
+  date: 18 - 22 Nov, 2024
+  location: Durham University
+  website: https://sites.google.com/view/durhamcompalggeom/home
+
+- title: MaRDI Annual Meeting 2024
+  end-date: "2024-11-20"
+  date: 18 - 20 Nov, 2024
+  location: Fraunhofer ITWM Kaiserslautern
+  website: https://www.itwm.fraunhofer.de/de/messen-veranstaltungen/2024/2024_11_18_mardi-annual-meeting.html

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,17 +1,17 @@
 - title: LEAN meets MaRDI and OSCAR
-  end-date: "2024-12-05"
-  date: 5 - 6 Dec, 2024
+  end-date: "2024-12-06"
+  start-date: "2024-12-05"
   location: TU Berlin
   website: https://polymake.org/doku.php/workshops/lean_workshop1224
 
 - title: Computational Algebraic Geometry Workshop
   end-date: "2024-11-22"
-  date: 18 - 22 Nov, 2024
+  start-date: "2024-11-18"
   location: Durham University
   website: https://sites.google.com/view/durhamcompalggeom/home
 
 - title: MaRDI Annual Meeting 2024
   end-date: "2024-11-20"
-  date: 18 - 20 Nov, 2024
+  start-date: "2024-11-18"
   location: Fraunhofer ITWM Kaiserslautern
   website: https://www.itwm.fraunhofer.de/de/messen-veranstaltungen/2024/2024_11_18_mardi-annual-meeting.html

--- a/index.md
+++ b/index.md
@@ -13,7 +13,7 @@ title: Home
 
 ## Upcoming events
 
-{% assign sorted_conferences = site.data.conferences | sort: "end-date" | reverse %}
+{% assign sorted_conferences = site.data.conferences | sort: "end-date" %}
 {% assign today = "now" | date: "%Y-%m-%d" %}
 
 {% for event in sorted_conferences %}

--- a/index.md
+++ b/index.md
@@ -10,11 +10,17 @@ title: Home
 
 # {{ site.title }}
 
+
 ## Upcoming events
 
-* [LEAN meets MaRDI and OSCAR (5 - 6 Dec, 2024 at TU Berlin).](https://polymake.org/doku.php/workshops/lean_workshop1224)
-* [Computational Algebraic Geometry Workshop (18 - 22 Nov, 2024 at Durham University).](https://sites.google.com/view/durhamcompalggeom/home)
-* [MaRDI Annual Meeting 2024 (18 - 20 Nov, 2024 at Fraunhofer ITWM Kaiserslautern)](https://www.itwm.fraunhofer.de/de/messen-veranstaltungen/2024/2024_11_18_mardi-annual-meeting.html)
+{% assign sorted_conferences = site.data.conferences | sort: "end-date" | reverse %}
+{% assign today = "now" | date: "%Y-%m-%d" %}
+
+{% for event in sorted_conferences %}
+  {% if event.end-date >= today %}
+* [{{ event.title }} ({{ event.date }} at {{ event.location }})]({{ event.website }})
+  {% endif %}
+{% endfor %}
 
 
 ## What is OSCAR?

--- a/index.md
+++ b/index.md
@@ -13,12 +13,13 @@ title: Home
 
 ## Upcoming events
 
-{% assign sorted_conferences = site.data.conferences | sort: "start-date" %}
+{% assign sorted_conferences = site.data.conferences | group-by: "start-date" | sort: "end-date"%}
 {% assign today = "now" | date: "%Y-%m-%d" %}
 
 {% for event in sorted_conferences %}
   {% if event.end-date >= today %}
-* [{{ event.title }} ({{ event.location }}, {{ event.start-date }} to {{ event.end-date }})]({{ event.website }})
+* [{{ event.title }} ({{ event.location }}, {{ event.start-date | date: "%d %b %Y" }} to {{ event.end-date | date: "%d %b %Y" }})]({{ event.website }})
+
   {% endif %}
 {% endfor %}
 

--- a/index.md
+++ b/index.md
@@ -13,12 +13,12 @@ title: Home
 
 ## Upcoming events
 
-{% assign sorted_conferences = site.data.conferences | sort: "end-date" %}
+{% assign sorted_conferences = site.data.conferences | sort: "start-date" %}
 {% assign today = "now" | date: "%Y-%m-%d" %}
 
 {% for event in sorted_conferences %}
   {% if event.end-date >= today %}
-* [{{ event.title }} ({{ event.date }} at {{ event.location }})]({{ event.website }})
+* [{{ event.title }} ({{ event.location }}, {{ event.start-date }} to {{ event.end-date }})]({{ event.website }})
   {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
When building the website, the list of upcoming conferences is automatically updated. Also, relative to this very build date, any past events are hidden.

Since events typically stretch out over a couple of days, I introduced the field "end-date", which is used to tell if an event happened in the past. This is not to be confused with the date field, which lists the period during which the event will/does/did take place.