### PR TITLE
Ak96/ci contrib list

### DIFF
--- a/.github/workflows/update-contrib.yml
+++ b/.github/workflows/update-contrib.yml
@@ -42,18 +42,11 @@ jobs:
         git add _data/people_list.yml
         git commit -m "Update contributors on $(date +'%Y-%m-%d')" || ${echo "No changes to commit" && false}
 
-    - name: Grab content from summary file
-      id: getsummary
-      run: |
-        echo 'foo<<EOF' >> $GITHUB_OUTPUT
-        echo $(cat summary.txt) >> $GITHUB_OUTPUT
-        echo 'EOF' >> $GITHUB_OUTPUT
-
     # Create a pull request
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v5
+      uses: peter-evans/create-pull-request@v7
       with:
         commit-message: "Update contributors on $(date +'%Y-%m-%d')"
         branch: update-contributors
         title: "Update contributors"
-        body: "${{ steps.getsummary.outputs.foo }}"
+        body-path: summary.txt

--- a/.github/workflows/update-contrib.yml
+++ b/.github/workflows/update-contrib.yml
@@ -28,6 +28,7 @@ jobs:
         source /tmp/pyvenv/bin/activate
         cd etc
         python update-contributors.py
+        cd ..
 
     # Configure Git for the PR
     - name: Set up Git

--- a/.github/workflows/update-contrib.yml
+++ b/.github/workflows/update-contrib.yml
@@ -17,12 +17,16 @@ jobs:
       uses: actions/checkout@v3
       
     # Run the update script
-    - name: Install python yaml
-      run: pip install pyyaml
+    - name: Setup venv and install pyyaml
+      run: |
+        python3 -m venv /tmp/pyvenv
+        source /tmp/pyvenv/bin/activate
+        pip install pyyaml
 
     - name: Run update-contributors script
       run: |
-        python3 /etc/update-contributors.py
+        source /tmp/pyvenv/bin/activate
+        python etc/update-contributors.py
 
     # Configure Git for the PR
     - name: Set up Git

--- a/.github/workflows/update-contrib.yml
+++ b/.github/workflows/update-contrib.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Read summary file
       id: getsummary
-      run: echo "::set-output name=summary::$(cat summary.txt)"
+      run: echo "{summary}={$(cat summary.txt)}" >> $GITHUB_OUTPUT
 
     # Create a pull request
     - name: Create Pull Request

--- a/.github/workflows/update-contrib.yml
+++ b/.github/workflows/update-contrib.yml
@@ -42,6 +42,10 @@ jobs:
         git add _data/people_list.yml
         git commit -m "Update contributors on $(date +'%Y-%m-%d')" || ${echo "No changes to commit" && false}
 
+    - name: Read summary file
+      id: getsummary
+      run: echo "::set-output name=summary::$(cat summary.txt)"
+
     # Create a pull request
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v5
@@ -49,5 +53,4 @@ jobs:
         commit-message: "Update contributors on $(date +'%Y-%m-%d')"
         branch: update-contributors
         title: "Update contributors"
-        body: |
-          This PR updates the contributors list based on the latest changes.
+        body: "${steps.getsummary.outputs.summary}"

--- a/.github/workflows/update-contrib.yml
+++ b/.github/workflows/update-contrib.yml
@@ -56,4 +56,4 @@ jobs:
         commit-message: "Update contributors on $(date +'%Y-%m-%d')"
         branch: update-contributors
         title: "Update contributors"
-        body: "${{ foo }}"
+        body: "${{ steps.getsummary.outputs.foo }}"

--- a/.github/workflows/update-contrib.yml
+++ b/.github/workflows/update-contrib.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Commit Changes
       run: |
         git add _data/people_list.yml
-        git commit -m "Update contributors on $(date +'%Y-%m-%d')" || echo "No changes to commit" && false
+        git commit -m "Update contributors on $(date +'%Y-%m-%d')" || ${echo "No changes to commit" && false}
 
     # Create a pull request
     - name: Create Pull Request

--- a/.github/workflows/update-contrib.yml
+++ b/.github/workflows/update-contrib.yml
@@ -42,6 +42,13 @@ jobs:
         git add _data/people_list.yml
         git commit -m "Update contributors on $(date +'%Y-%m-%d')" || ${echo "No changes to commit" && false}
 
+    - name: Grab content from summary file
+      id: getsummary
+      run: |
+        echo 'foo<<EOF' >> $GITHUB_OUTPUT
+        echo $(cat summary.txt) >> $GITHUB_OUTPUT
+        echo 'EOF' >> $GITHUB_OUTPUT
+
     # Create a pull request
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v5
@@ -49,4 +56,4 @@ jobs:
         commit-message: "Update contributors on $(date +'%Y-%m-%d')"
         branch: update-contributors
         title: "Update contributors"
-        body: "$(cat summary.txt)"
+        body: "${{ env.foo }}"

--- a/.github/workflows/update-contrib.yml
+++ b/.github/workflows/update-contrib.yml
@@ -56,4 +56,4 @@ jobs:
         commit-message: "Update contributors on $(date +'%Y-%m-%d')"
         branch: update-contributors
         title: "Update contributors"
-        body: "${{ env.foo }}"
+        body: "${{ foo }}"

--- a/.github/workflows/update-contrib.yml
+++ b/.github/workflows/update-contrib.yml
@@ -26,7 +26,8 @@ jobs:
     - name: Run update-contributors script
       run: |
         source /tmp/pyvenv/bin/activate
-        python etc/update-contributors.py
+        cd etc
+        python update-contributors.py
 
     # Configure Git for the PR
     - name: Set up Git

--- a/.github/workflows/update-contrib.yml
+++ b/.github/workflows/update-contrib.yml
@@ -42,10 +42,6 @@ jobs:
         git add _data/people_list.yml
         git commit -m "Update contributors on $(date +'%Y-%m-%d')" || ${echo "No changes to commit" && false}
 
-    - name: Read summary file
-      id: getsummary
-      run: echo "{summary}={$(cat summary.txt)}" >> $GITHUB_OUTPUT
-
     # Create a pull request
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v5
@@ -53,4 +49,4 @@ jobs:
         commit-message: "Update contributors on $(date +'%Y-%m-%d')"
         branch: update-contributors
         title: "Update contributors"
-        body: "${{steps.getsummary.outputs.summary}}"
+        body: "$(cat summary.txt)"

--- a/.github/workflows/update-contrib.yml
+++ b/.github/workflows/update-contrib.yml
@@ -53,4 +53,4 @@ jobs:
         commit-message: "Update contributors on $(date +'%Y-%m-%d')"
         branch: update-contributors
         title: "Update contributors"
-        body: "${steps.getsummary.outputs.summary}"
+        body: "${{steps.getsummary.outputs.summary}}"

--- a/.github/workflows/update-contrib.yml
+++ b/.github/workflows/update-contrib.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         python3 -m venv /tmp/pyvenv
         source /tmp/pyvenv/bin/activate
-        pip install pyyaml
+        pip install pyyaml requests
 
     - name: Run update-contributors script
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ _data/examples_with_updated_last_modified.yml
 _data/examples_status.yml
 _data/autogen_people_list.yml
 etc/repos/*
+summary.txt

--- a/_data/people_list.yml
+++ b/_data/people_list.yml
@@ -455,6 +455,7 @@
   affiliation: University of Kaiserslautern-Landau
   status: retired
   comment: Was PostDoc in Kaiserslautern around 2021
+  github: GDeFranceschi
 
 - name: Alexander Dinges
   affiliation: University of Kaiserslautern-Landau

--- a/contributors.md
+++ b/contributors.md
@@ -12,7 +12,7 @@ title: Contributors
 ## Project leaders
 
 <ul>
-{% for p in site.data.autogen_people_list %}
+{% for p in site.data.people_list %}
   {% if p.status == "pi" %}
     <li>
       <a href="{{ p.website }}"><strong>{{ p.name }}</strong></a>, {{ p.affiliation }}
@@ -30,7 +30,7 @@ The following people are actively[^1] contributing to the OSCAR project.
 
 
 <ul>
-{% for p in site.data.autogen_people_list %}
+{% for p in site.data.people_list %}
   {% if p.status == "active" %}
   <li>
     {% if p.website != null %}
@@ -69,7 +69,7 @@ not contributed code changes in the past 12 months[^1].
 [^1]: This list was last updated on {{ 'now' | date: "%d %b %Y" }}.
 
 <ul>
-{% for p in site.data.autogen_people_list %}
+{% for p in site.data.people_list %}
   {% if p.status == "retired" %}
   <li>
     {% if p.website != null %}

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -22,9 +22,9 @@ infile = "../_data/people_list.yml"
 with open(infile, "r") as ymlfile:
     peopleList = yaml.safe_load(ymlfile)
 names = [i['github'] for i in peopleList]
-repoList = ["thofma/Hecke.jl"]#, "oscar-system/Oscar.jl", "Nemocas/Nemo.jl",
-            #"Nemocas/AbstractAlgebra.jl", "oscar-system/GAP.jl", "oscar-system/Polymake.jl",
-            #"oscar-system/Singular.jl"]
+repoList = ["thofma/Hecke.jl", "oscar-system/Oscar.jl", "Nemocas/Nemo.jl",
+            "Nemocas/AbstractAlgebra.jl", "oscar-system/GAP.jl", "oscar-system/Polymake.jl",
+            "oscar-system/Singular.jl"]
 
 newList = []
 namelist = []
@@ -33,7 +33,7 @@ github_userlist = []
 API_KEY = os.getenv("API_KEY") # TODO: rename to whatever is the right env var
 summarystring = "This PR updates the contributors list based on the latest changes.\n"
 # grab currently active devs
-if not os.path.isdir("repos"): #bla a a
+if not os.path.isdir("repos"):
     os.mkdir("repos")
 os.chdir("repos")
 for repo in repoList:

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -33,7 +33,7 @@ github_userlist = []
 API_KEY = os.getenv("API_KEY") # TODO: rename to whatever is the right env var
 
 # grab currently active devs
-if not os.path.isdir("repos"):
+if not os.path.isdir("repos"): #bla
     os.mkdir("repos")
 os.chdir("repos")
 for repo in repoList:

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -33,7 +33,7 @@ github_userlist = []
 API_KEY = os.getenv("API_KEY") # TODO: rename to whatever is the right env var
 
 # grab currently active devs
-if not os.path.isdir("repos"): #bla
+if not os.path.isdir("repos"): #bla a
     os.mkdir("repos")
 os.chdir("repos")
 for repo in repoList:

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -71,6 +71,8 @@ for repo in repoList:
         r = requests.get(github_commit_url, headers={"Authorization":f"Bearer {API_KEY}"})
         if r.status_code == 200:
             j = json.loads(r.text)
+            if j['author'] == None:
+                continue
             github_username = j['author']['login']
         else:
             # this will never happen, except if the API lies to you

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -22,16 +22,16 @@ infile = "../_data/people_list.yml"
 with open(infile, "r") as ymlfile:
     peopleList = yaml.safe_load(ymlfile)
 names = [i['github'] for i in peopleList]
-repoList = ["thofma/Hecke.jl", "oscar-system/Oscar.jl", "Nemocas/Nemo.jl",
-            "Nemocas/AbstractAlgebra.jl", "oscar-system/GAP.jl", "oscar-system/Polymake.jl",
-            "oscar-system/Singular.jl"]
+repoList = ["thofma/Hecke.jl"]#, "oscar-system/Oscar.jl", "Nemocas/Nemo.jl",
+            #"Nemocas/AbstractAlgebra.jl", "oscar-system/GAP.jl", "oscar-system/Polymake.jl",
+            #"oscar-system/Singular.jl"]
 
 newList = []
 namelist = []
 github_newusers = []
 github_userlist = []
 API_KEY = os.getenv("API_KEY") # TODO: rename to whatever is the right env var
-
+summarystring = "This PR updates the contributors list based on the latest changes.\n"
 # grab currently active devs
 if not os.path.isdir("repos"): #bla a a
     os.mkdir("repos")
@@ -72,6 +72,7 @@ for repo in repoList:
         if r.status_code == 200:
             j = json.loads(r.text)
             if j['author'] == None:
+                summarystring += f" - Github username not found for {i[0]} with email {i[1]}. Excluding from people_list.yml\n"
                 continue
             github_username = j['author']['login']
         else:
@@ -128,3 +129,6 @@ with open('../_data/people_list.yml', 'w') as outfile:
     yaml.dump(activelist, outfile, Dumper=MyDumper, sort_keys=False)
     outfile.write("\n######################\n# Retired contributors\n######################\n\n")
     yaml.dump(retiredlist, outfile, Dumper=MyDumper, sort_keys=False)
+
+with open("../summary.txt", 'w') as summaryfile:
+    summaryfile.write(summarystring)

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -33,7 +33,7 @@ github_userlist = []
 API_KEY = os.getenv("API_KEY") # TODO: rename to whatever is the right env var
 
 # grab currently active devs
-if not os.path.isdir("repos"): #bla a
+if not os.path.isdir("repos"): #bla a a
     os.mkdir("repos")
 os.chdir("repos")
 for repo in repoList:


### PR DESCRIPTION
Changes in this PR enable a bot to make PRs like #392 . This can be merged once we figure out what to do with the "continue case", i.e., if a commit was made by someone in git, but pushed by someone else to github, the github API returns the author of the commit as `None`. Currently we skip cases like this, but this should be handled. ( cf. `etc/update-contributors.py:75` | currently happens with `['Jens Brandt', 'jens.brandt@rwth-aachen.de]` ), and he is not included in the contributor's list (mostly so we can reproduce the problem).

cc @HereAround 