### PR TITLE
Ak96/update update script

### DIFF
--- a/.github/workflows/update-contrib.yml
+++ b/.github/workflows/update-contrib.yml
@@ -21,13 +21,12 @@ jobs:
     # Run the update script
     - name: Setup venv and install pyyaml
       run: |
-        python3 -m venv /tmp/pyvenv
-        source /tmp/pyvenv/bin/activate
         pip install pyyaml requests
 
     - name: Run update-contributors script
+      env:
+        API_KEY: ${{secrets.API_KEY}}
       run: |
-        source /tmp/pyvenv/bin/activate
         cd etc
         python update-contributors.py
         cd ..

--- a/.github/workflows/update-contrib.yml
+++ b/.github/workflows/update-contrib.yml
@@ -51,3 +51,4 @@ jobs:
         branch: update-contributors
         title: "Update contributors"
         body-path: summary.txt
+        base: gh-pages

--- a/.github/workflows/update-contrib.yml
+++ b/.github/workflows/update-contrib.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   update-contributors:
-    runs-on: debian-01
+    runs-on: ubuntu-22.04
 
     steps:
     # Checkout the repository

--- a/.github/workflows/update-contrib.yml
+++ b/.github/workflows/update-contrib.yml
@@ -3,6 +3,8 @@ name: Update Contributors
 # Schedule: Runs at midnight on the first day of each month
 on:
   push:
+    branches:
+      - gh-pages
   workflow_dispatch:
   schedule:
     - cron: '0 0 1 * *'  # At 00:00 UTC on the 1st of every month

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -15,9 +15,6 @@ class MyDumper(yaml.SafeDumper):
         if len(self.indents) == 1:
             super().write_line_break()
 
-# we don't want to overwrite the manually curated people_list
-# but we also need to include the autogen file if available
-# to keep a better track of retired people
 infile = "../_data/people_list.yml"
 with open(infile, "r") as ymlfile:
     peopleList = yaml.safe_load(ymlfile)
@@ -124,11 +121,11 @@ activelist = [i for i in sortedPeopleList if i['status'] == "active"]
 retiredlist = [i for i in sortedPeopleList if i['status'] == "retired"]
 with open('../_data/people_list.yml', 'w') as outfile:
     outfile.write("######################\n# Project leads\n######################\n\n")
-    yaml.dump(pilist, outfile, Dumper=MyDumper, sort_keys=False)
+    yaml.dump(pilist, outfile, Dumper=MyDumper, sort_keys=False, allow_unicode=True)
     outfile.write("\n######################\n# Active contributors\n######################\n\n")
-    yaml.dump(activelist, outfile, Dumper=MyDumper, sort_keys=False)
+    yaml.dump(activelist, outfile, Dumper=MyDumper, sort_keys=False, allow_unicode=True)
     outfile.write("\n######################\n# Retired contributors\n######################\n\n")
-    yaml.dump(retiredlist, outfile, Dumper=MyDumper, sort_keys=False)
+    yaml.dump(retiredlist, outfile, Dumper=MyDumper, sort_keys=False, allow_unicode=True)
 
 with open("../summary.txt", 'w') as summaryfile:
     summaryfile.write(summarystring)

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -7,7 +7,8 @@ import subprocess
 
 def custom_sort_function(item):
     name, _ = item
-    sortweight = {"name": 0, "affiliation": 1, "email": 2, "github": 3, "website": 4, "status": 5}
+    sortweight = {"name": 0, "affiliation": 1, "email": 2, "github": 3, "website": 4,
+                  "paid_by_dfg" 5:,"status": 6}
     return sortweight[name]
 
 # Hack copied from https://github.com/yaml/pyyaml/issues/127#issuecomment-525800484

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -8,7 +8,7 @@ import subprocess
 def custom_sort_function(item):
     name, _ = item
     sortweight = {"name": 0, "affiliation": 1, "email": 2, "github": 3, "website": 4,
-                  "paid_by_dfg": 5,"status": 6}
+                  "paid_by_dfg": 5,"status": 6, "comment": 7}
     return sortweight[name]
 
 # Hack copied from https://github.com/yaml/pyyaml/issues/127#issuecomment-525800484

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -8,7 +8,7 @@ import subprocess
 def custom_sort_function(item):
     name, _ = item
     sortweight = {"name": 0, "affiliation": 1, "email": 2, "github": 3, "website": 4,
-                  "paid_by_dfg" 5:,"status": 6}
+                  "paid_by_dfg": 5,"status": 6}
     return sortweight[name]
 
 # Hack copied from https://github.com/yaml/pyyaml/issues/127#issuecomment-525800484

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -5,6 +5,11 @@ import yaml
 import requests
 import subprocess
 
+def custom_sort_function(item):
+    name, _ = item
+    sortweight = {"name": 0, "affiliation": 1, "email": 2, "github": 3, "website": 4, "status": 5}
+    return sortweight[name]
+
 # Hack copied from https://github.com/yaml/pyyaml/issues/127#issuecomment-525800484
 class MyDumper(yaml.SafeDumper):
     # HACK: insert blank lines between top-level objects
@@ -116,9 +121,9 @@ sortedPeopleList = sorted(peopleList, key= lambda d: d['name'].split()[-1])
 
 # save yml to *NEW* file
 # how inefficient is list comprehension ?
-pilist = [i for i in sortedPeopleList if i['status'] == "pi"]
-activelist = [i for i in sortedPeopleList if i['status'] == "active"]
-retiredlist = [i for i in sortedPeopleList if i['status'] == "retired"]
+pilist = [dict(sorted(i.items(), key=custom_sort_function)) for i in sortedPeopleList if i['status'] == "pi"]
+activelist = [dict(sorted(i.items(), key=custom_sort_function)) for i in sortedPeopleList if i['status'] == "active"]
+retiredlist = [dict(sorted(i.items(), key=custom_sort_function)) for i in sortedPeopleList if i['status'] == "retired"]
 with open('../_data/people_list.yml', 'w') as outfile:
     outfile.write("######################\n# Project leads\n######################\n\n")
     yaml.dump(pilist, outfile, Dumper=MyDumper, sort_keys=False, allow_unicode=True)


### PR DESCRIPTION
Should fix the following issues pointed out by @fingolfin 

 - I am annoyed that it replaces perfectly fine UTF-8 by hex encoded values
 - another feature request: in people_list.yml can we sort the keys of entries?
   Things are now sorted as follows : name, affiliation, email, github, website, paid_by_dfg, status, comment. Not alphabetically, but it is how I would like to read things if I were scanning through the file with my own eyes.

As a bonus, we also now only run the update/PR action when someone pushes to gh-pages, and the base branch for the automatic PRs is always gh-pages.