### PR TITLE
CI: limit concurrency for update-contrib workflow

### DIFF
--- a/.github/workflows/update-contrib.yml
+++ b/.github/workflows/update-contrib.yml
@@ -9,6 +9,12 @@ on:
   schedule:
     - cron: '0 0 1 * *'  # At 00:00 UTC on the 1st of every month
 
+# only run at most one instances of this workflow at a time for each branch
+# resp. tag. Starting a new one cancels previously running ones.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update-contributors:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
If multiple PRs are merged into master in a row, we don't want them all to run, just the one on the latest commit.