### PR TITLE
Don't fail when there were no commits 

### DIFF
--- a/.github/workflows/update-contrib.yml
+++ b/.github/workflows/update-contrib.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Commit Changes
       run: |
         git add _data/people_list.yml
-        git commit -m "Update contributors on $(date +'%Y-%m-%d')" || ${echo "No changes to commit" && false}
+        git commit -m "Update contributors on $(date +'%Y-%m-%d')"
 
     # Create a pull request
     - name: Create Pull Request


### PR DESCRIPTION
The PR action will fail silently in such cases anyway, and we won't get a red check mark on pushes.