### PR TITLE
Fix the false error we currently get

### DIFF
--- a/.github/workflows/update-contrib.yml
+++ b/.github/workflows/update-contrib.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Commit Changes
       run: |
         git add _data/people_list.yml
-        git commit -m "Update contributors on $(date +'%Y-%m-%d')"
+        git commit -m "Update contributors on $(date +'%Y-%m-%d')" || echo "Nothing to commit!"
 
     # Create a pull request
     - name: Create Pull Request


### PR DESCRIPTION
This should fix the update-contributors action showing an error if there is nothing to commit.