### PR TITLE
Add new FTheoryTools tutorial

### DIFF
--- a/_data/examples.yml
+++ b/_data/examples.yml
@@ -36,6 +36,15 @@
   language: julia
   date: January 1, 1970
 
+- title: F-Theory Tools -- Advanced Functionality
+  repository: HereAround/MartinsOscarTutorials.jl
+  branch: master
+  filename: FTheoryToolsPaper
+  author: Martin Bies, Andrew P. Turner, Mikelis E. Mikelson
+  thumbnail: FTheoryTools.png
+  language: julia
+  date: January 1, 1970
+
 
 
 # Tutorials hosted at https://github.com/HechtiDerLachs/OscarTutorials


### PR DESCRIPTION
This is the current code in our draft. It would be tested now (I actually found a bug and fixed it), in that every command must execute without error. But the output is not tested to match the given form. Still, this is better than nothing.

Certainly, this needs updating if we make code changes in the draft. The notebook sits here:
https://github.com/HereAround/MartinsOscarTutorials.jl/blob/master/FTheoryToolsPaper.ipynb

So if you want to make updates, then you would open a PR to https://github.com/HereAround/MartinsOscarTutorials.jl.
(Alternatively, one of you can open a separate repo that we all have write access to. That is fine with me to. Or we use https://github.com/Julia-meets-String-Theory. Or...)

cc @apturner @emikelsons