### PR TITLE
Show "Other" installation page for unknown operating system

### DIFF
--- a/getting-started/install-linux.md
+++ b/getting-started/install-linux.md
@@ -42,7 +42,7 @@ sudo apt install build-essential
 ```
 
 If you are using Fedora 40 or newer, enter the following commands into a terminal (this will prompt for your password
-and requires that you have permissions to administer your computer).
+and requires that you have permissions to administer your computer):
 ```sh
 sudo dnf install gcc-c++ make
 ```
@@ -62,7 +62,7 @@ sudo dnf install gcc-c++ make
    ```sh
    curl -fsSL https://install.julialang.org | sh
    ```
-4. Alternatively, you can [download Julia directly from the official website](https://julialang.org/downloads/) and follow the [installation instructions for macOS]((https://julialang.org/downloads/platform/).
+4. Alternatively, you can [download Julia directly from the official website](https://julialang.org/downloads/) and follow the [installation instructions for Linux](https://julialang.org/downloads/platform/).
 
 
 ## Step 3: Install OSCAR

--- a/getting-started/install-mac.md
+++ b/getting-started/install-mac.md
@@ -56,7 +56,7 @@ If you are using macOS 10.12 or newer, you need to install the Xcode command lin
    ```sh
    curl -fsSL https://install.julialang.org | sh
    ```
-4. Alternatively, you can [download Julia directly from the official website](https://julialang.org/downloads/) and follow the [installation instructions for macOS]((https://julialang.org/downloads/platform/).
+4. Alternatively, you can [download Julia directly from the official website](https://julialang.org/downloads/) and follow the [installation instructions for macOS](https://julialang.org/downloads/platform/).
 
 
 ## Step 3: Install OSCAR

--- a/getting-started/install-win.md
+++ b/getting-started/install-win.md
@@ -52,7 +52,7 @@ Having trouble? Visit our [Contact & Support]({{site.baseurl}}/contact-and-suppo
    ```sh
    curl -fsSL https://install.julialang.org | sh
    ```
-5. Alternatively, you can [download Julia directly from the official website](https://julialang.org/downloads/) and follow the [installation instructions for Linux Ubuntu]((https://julialang.org/downloads/platform/).
+5. Alternatively, you can [download Julia directly from the official website](https://julialang.org/downloads/) and follow the [installation instructions for Linux Ubuntu](https://julialang.org/downloads/platform/).
 
 
 ## Step 3: Install OSCAR

--- a/getting-started/install.md
+++ b/getting-started/install.md
@@ -15,4 +15,7 @@ title: Installation Instructions
     else if (navigator.userAgent.includes("Macintosh")){
         window.location.replace("{{site.baseurl}}/getting-started/install-mac"+target);
     }
+    else {
+        window.location.replace("{{site.baseurl}}/getting-started/install-generic"+target);
+    }
 </script>


### PR DESCRIPTION
I accessed the "install" page with my phone and got a blank page. My suggestion is to show the "Other" page, so at least there is *something* and one gets the menu bar on the top.

Also fix a few typos.
