### PR TITLE
Fix broken link

### DIFF
--- a/credits/index.md
+++ b/credits/index.md
@@ -5,5 +5,5 @@ title: Credits and Citations
 
 - [Contributors]({{site.baseurl }}/credits/contributors/) – A list of OSCAR PIs, active members, and past contributors.  
 - [Software Credits]({{site.baseurl }}/credits/software-credits/) – The software projects OSCAR is built upon.  
-- [Citations]({{site.baseurl }}/credits/OSCAR-credits/) – Research papers that cite OSCAR.  
+- [Citations]({{site.baseurl }}/credits/bibliography/) – Research papers that cite OSCAR.  
 - [How to Cite OSCAR]({{site.baseurl }}/credits/Citing-OSCAR/) – Guidelines for citing OSCAR in your work.  


### PR DESCRIPTION
I guess was meant to redirect to the "bibliography" page. Currently URL is not found.