### PR TITLE
fix infinite redirect rule

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -14,5 +14,5 @@ RedirectMatch temp ^/install/(.*) https://www.oscar-system.org/getting-started/i
 RedirectMatch temp ^/tutorials/(.*) https://www.oscar-system.org/getting-started/tutorials/$1
 RedirectMatch temp ^/documentation/(.*) https://www.oscar-system.org/getting-started/documentation/$1
 RedirectMatch temp ^/community/(.*) https://www.oscar-system.org/contact-and-support/$1
-RedirectMatch permanent ^/credits/(.*) https://www.oscar-system.org/credits/software-credits/$1
-RedirectMatch permanent ^/contributors/(.*) https://www.oscar-system.org/credits/contributors/$1
+RedirectMatch permanent ^/credits/$ https://www.oscar-system.org/credits/software-credits/
+RedirectMatch permanent ^/contributors/$ https://www.oscar-system.org/credits/contributors/


### PR DESCRIPTION
Before this change, the rule for credits says "look at any URL with `/credits/` in it, and redirect it to `/credits/whatever-came-after-it`", and this turns it into an infinite loop. There was a similar problem with `/contributors/` (which redirected to `credits/contributors`, which then triggered the infinite loop from credits.

This change will (hopefully) make the redirect fire only if the URL is `/credits/` and nothing after it (because that was how the old website was). The same change is applied to `/contributors/` ( although not strictly necessary, I think it looks cleaner?)