### PR TITLE
change page link to match sidebar link

### DIFF
--- a/events/index.md
+++ b/events/index.md
@@ -3,7 +3,7 @@ layout: page
 title: Events
 ---
 
-### [OSCAR-organized Events]({{site.baseurl }}/events/oscar-events/)
+### [OSCAR-organized Events]({{site.baseurl }}/events/meetings/)
 OSCAR regularly organizes workshops, hackathons, and development meetings.
 
 ### [SFB-TRR 195 Events](https://www.computeralgebra.de/sfb/events/)


### PR DESCRIPTION
Minor typo which lead to a "not found" page. If we want the URL to actually be `oscar-events`, then we must change the link on the sidebar, and the actual target for the page.