### PR TITLE
Improve layout to make it easier to find documentation (and tutorials)

### DIFF
--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -14,7 +14,7 @@
 - title: "Getting Started"
   url: "/getting-started/"
   submenu:
-    - title: "Install "
+    - title: "Installation"
       url: "/getting-started/install"
     - title: "Tutorials"
       url: "/getting-started/tutorials/"

--- a/index.md
+++ b/index.md
@@ -36,19 +36,21 @@ Currently no upcoming events.
 
 ## 🚀 Get OSCAR {{ site.data.release.version }}
 
-The latest stable release of OSCAR is **v{{ site.data.release.version }}**. Getting started is easy – [**follow our guide here!**]({{site.baseurl}}/getting-started/)
+The latest stable release of OSCAR is **v{{ site.data.release.version }}**. Getting started is easy – [**follow our installation guide here!**]({{site.baseurl }}/getting-started/install/)
 
 ---
+
+## 📚 Tutorials & Documentation
+
+- [**Hands-on Tutorials**]({{site.baseurl }}/getting-started/tutorials/).
+- [**Comprehensive Documentation**]({{site.baseurl }}/getting-started/documentation/).
+
+---
+
 ## 📙 The OSCAR Book
 
 The [OSCAR Book](https://book.oscar-system.org/) – A detailed guide to version 1.0, featuring code snippets and in-depth explanations.
 
----
-
-## 📚 Documentation & Tutorials
-
-- Comprehensive [Documentation]({{site.baseurl }}/getting-started/documentation/).
-- Hands-on [Tutorials]({{site.baseurl }}/getting-started/tutorials/).
 
 ---
 


### PR DESCRIPTION
@aaruni96, this is to address the point raised by @YueRen yesterday, i.e. enhancing discoverability of the documentation (and tutorials).

While we have links on the main landing page (and I have tried to make them more prominent), it would be nice to have also links available in the sidebar. The easiest fix for this is to make sure that the "getting started" submenu is always expanded. ~~If you agree with this proposal, I will likely need your help with the css magic to ensure that this submenu is always expanded.~~