### PR TITLE
Events: ensure internal links use baseurl

### DIFF
--- a/events/meetings.md
+++ b/events/meetings.md
@@ -12,7 +12,7 @@ meeting: true
       <strong>{{ event.title }}</strong><br>
       <em>{{ event.start-date }} – {{ event.end-date }}</em><br>
       Location: {{ event.location }}<br>
-      <a href="{{ event.website }}" target="_blank">More information</a>
+      <a href="{{ event.website | replace: "https://www.oscar-system.org", site.baseurl }}" target="_blank">More information</a>
     </li>
     <br>
   {% endfor %}

--- a/events/meetings/2021-09/index.md
+++ b/events/meetings/2021-09/index.md
@@ -45,4 +45,4 @@ This workshop is supported by [SFB-TRR 195](https://www.computeralgebra.de/sfb/)
 
 ## Other meetings
 
-Please visit [the meetings page]({{ site.baseurl }}/meetings) for an overview of the OSCAR meetings.
+Please visit [the meetings page]({{ site.baseurl }}/events/meetings) for an overview of the OSCAR meetings.

--- a/events/satellite-events.md
+++ b/events/satellite-events.md
@@ -14,7 +14,7 @@ SFB-TRR 195 events are listed [here](https://www.computeralgebra.de/sfb/events/)
       <strong>{{ event.title }}</strong><br>
       <em>{{ event.start-date }} – {{ event.end-date }}</em><br>
       Location: {{ event.location }}<br>
-      <a href="{{ event.website }}" target="_blank">More information</a>
+      <a href="{{ event.website | replace: "https://www.oscar-system.org", site.baseurl }}" target="_blank">More information</a>
     </li>
     <br>
   {% endfor %}


### PR DESCRIPTION
The same as https://github.com/oscar-system/oscar-website/pull/462, but that forgot event links at some other places.