### PR TITLE
Make local deployment work (for Arch linux?)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,8 @@ gem "webrick", "~> 1.7"
 gem "sassc", "2.1.0"
 gem "logger", "1.4.2"
 
-# Some gems that are getting removed from the standard library, but are not a dep of jekyll
+# Some gems that are getting removed from the standard library, but are not declared as a
+# dependency of jekyll, yet without them ruby throws errors (at least on some system)
 gem "base64"
 gem "csv"
 gem "erb"

--- a/Gemfile
+++ b/Gemfile
@@ -29,3 +29,9 @@ end
 gem "webrick", "~> 1.7"
 gem "sassc", "2.1.0"
 gem "logger", "1.4.2"
+
+# Some gems that are getting removed from the standard library, but are not a dep of jekyll
+gem "base64"
+gem "csv"
+gem "erb"
+gem "ostruct"


### PR DESCRIPTION
This change is needed since otherwise calling `bundle exec jekyll serve` results in 
```
bundler: failed to load command: jekyll (/home/lgoe/.local/share/gem/ruby/3.3.0/bin/jekyll)
/usr/lib/ruby/3.3.0/bundled_gems.rb:69:in `require': cannot load such file -- erb (LoadError)
Did you mean?  drb
        from /usr/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
        from /home/lgoe/.local/share/gem/ruby/3.3.0/gems/jekyll-4.2.2/lib/jekyll/commands/new.rb:3:in `<top (required)>'
        from /usr/lib/ruby/3.3.0/bundled_gems.rb:69:in `require'
        from /usr/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
        from /home/lgoe/.local/share/gem/ruby/3.3.0/gems/jekyll-4.2.2/lib/jekyll.rb:13:in `block in require_all'
        from /home/lgoe/.local/share/gem/ruby/3.3.0/gems/jekyll-4.2.2/lib/jekyll.rb:12:in `each'
        from /home/lgoe/.local/share/gem/ruby/3.3.0/gems/jekyll-4.2.2/lib/jekyll.rb:12:in `require_all'
        from /home/lgoe/.local/share/gem/ruby/3.3.0/gems/jekyll-4.2.2/lib/jekyll.rb:188:in `<top (required)>'
        from /usr/lib/ruby/3.3.0/bundled_gems.rb:69:in `require'
        from /usr/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
        from /home/lgoe/.local/share/gem/ruby/3.3.0/gems/jekyll-4.2.2/exe/jekyll:8:in `<top (required)>'
        from /home/lgoe/.local/share/gem/ruby/3.3.0/bin/jekyll:25:in `load'
        from /home/lgoe/.local/share/gem/ruby/3.3.0/bin/jekyll:25:in `<top (required)>'
        from /home/lgoe/.local/share/gem/ruby/3.3.0/gems/bundler-2.6.6/lib/bundler/cli/exec.rb:59:in `load'
        from /home/lgoe/.local/share/gem/ruby/3.3.0/gems/bundler-2.6.6/lib/bundler/cli/exec.rb:59:in `kernel_load'
        from /home/lgoe/.local/share/gem/ruby/3.3.0/gems/bundler-2.6.6/lib/bundler/cli/exec.rb:23:in `run'
        from /home/lgoe/.local/share/gem/ruby/3.3.0/gems/bundler-2.6.6/lib/bundler/cli.rb:452:in `exec'
        from /home/lgoe/.local/share/gem/ruby/3.3.0/gems/bundler-2.6.6/lib/bundler/vendor/thor/lib/thor/command.rb:28:in `run'
        from /home/lgoe/.local/share/gem/ruby/3.3.0/gems/bundler-2.6.6/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
        from /home/lgoe/.local/share/gem/ruby/3.3.0/gems/bundler-2.6.6/lib/bundler/vendor/thor/lib/thor.rb:538:in `dispatch'
        from /home/lgoe/.local/share/gem/ruby/3.3.0/gems/bundler-2.6.6/lib/bundler/cli.rb:35:in `dispatch'
        from /home/lgoe/.local/share/gem/ruby/3.3.0/gems/bundler-2.6.6/lib/bundler/vendor/thor/lib/thor/base.rb:584:in `start'
        from /home/lgoe/.local/share/gem/ruby/3.3.0/gems/bundler-2.6.6/lib/bundler/cli.rb:29:in `start'
        from /home/lgoe/.local/share/gem/ruby/3.3.0/gems/bundler-2.6.6/exe/bundle:28:in `block in <top (required)>'
        from /home/lgoe/.local/share/gem/ruby/3.3.0/gems/bundler-2.6.6/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
        from /home/lgoe/.local/share/gem/ruby/3.3.0/gems/bundler-2.6.6/exe/bundle:20:in `<top (required)>'
        from /usr/bin/bundle:25:in `load'
        from /usr/bin/bundle:25:in `<main>'
```
This could be due to a problem with my local setup, but I was not able to track it down. (Removing everything ruby related from my system and re-installing didn't help).