### PR TITLE
Rewrite in python / add fallback for network failures

### DIFF
--- a/etc/tutorial_status.py
+++ b/etc/tutorial_status.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+import os
+from github import Github, Auth
+
+API_KEY = os.getenv("API_KEY")
+
+auth = Auth.Token(API_KEY)
+
+g = Github(auth=auth)
+failed=False
+
+try:
+    # anything that calls out to a network, and might face a transient error
+    repo = g.get_repo("oscar-system/TutorialTesterforOscar")
+    workflow = repo.get_workflow("CI.yml")
+    run = workflow.get_runs()[0]    # get most recent run
+    jobs = run.jobs()
+except Exception as e:
+    print(e)
+    falied = True
+
+resultstring = ""
+
+if not failed:
+    # if failed, resultstring remains empty, and all tutorials are marked as "out of date"
+    # is this a good idea? maybe we should assume everything is current if we can't tell for sure?
+    for i in jobs:
+        if i.name == "Prepare Tests":
+            continue
+        name = i.name.split()[-1][0:-1]
+        status = i.conclusion
+        resultstring += f"{name}: {status}\n"
+
+if os.getcwd().split('/')[-1] == 'etc':
+    statusfilepath = "../_data/examples_status"
+else:
+    statusfilepath = "_data/examples_status"
+
+with open(statusfilepath, 'w') as statusfile:
+    statusfile.write(resultstring)

--- a/etc/update-dates.py
+++ b/etc/update-dates.py
@@ -1,37 +1,46 @@
-import json
+#!/usr/bin/env python3
+
+import os
 import yaml
-import requests
 
 from datetime import datetime
+from github import Github, Auth
 
-ogfile = yaml.safe_load(open("../_data/examples.yml"))
+API_KEY = os.getenv("API_KEY")
+
+auth = Auth.Token(API_KEY)
+
+g = Github(auth=auth)
+failed=False
+
+if os.getcwd().split('/')[-1] == 'etc':
+    ogfile = yaml.safe_load(open("../_data/examples.yml"))
+else:
+    ogfile = yaml.safe_load(open("_data/examples.yml"))
 
 for i in range(len(ogfile)):
-    #assemble URL
-    repo = f"{ogfile[i]['repository']}"
-    filepath = f"{ogfile[i]['filename']}.ipynb"
-    url = f'https://api.github.com/repos/{repo}/commits?path={filepath}'
-
-    # fallback default date
-    dt = datetime(1970, 1, 1)
 
     try:
-        #make request
-        #unauth API is rate limited at 60 per hour
-        #this should be okay for running script once per hour (we have less than 60 tutorials)
-        #auth API usage has limit of 5,000 requests per hour.
-        r = requests.get(url)
-        if r.status_code != 200:
-            raise ValueError(f"Reponse must have code 200, we got {r.status_code}")
-        r = json.loads(r.content)
-        dt = datetime.strptime(r[0]['commit']['author']['date'], "%Y-%m-%dT%H:%M:%SZ")    
+        # all network requests are in this try block
+        reponame = f"{ogfile[i]['repository']}"
+        filepath = f"{ogfile[i]['filename']}.ipynb"
+        print(f"Getting {reponame}/{filepath}...")
+        repo = g.get_repo(reponame)
+        commit = repo.get_commits(path=filepath)[0]
+        dt = commit.stats.last_modified_datetime
     except Exception as e:
         print(e)
-        print(f"Got an error {e}.\nUsing default date for {ogfile[i]['filename']}...")
+        print("Network access failed. Using fallback default date.")
+        dt = datetime(1970, 1, 1)
 
     #update times
     d = dt.date().strftime("%B %d, %Y")
     ogfile[i]['date'] = d
 
-with open('../_data/examples_with_updated_last_modified.yml', 'w') as outfile:
+if os.getcwd().split('/')[-1] == 'etc':
+    outfilepath = '../_data/examples_with_updated_last_modified.yml'
+else:
+    outfilepath = "_data/examples_with_updated_last_modified.yml"
+
+with open(outfilepath, 'w') as outfile:
     outfile.write(yaml.dump(ogfile))

--- a/etc/update-latest-release.py
+++ b/etc/update-latest-release.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+import os
+
+from datetime import datetime
+from github import Github, Auth
+
+API_KEY = os.getenv("API_KEY")
+
+auth = Auth.Token(API_KEY)
+
+g = Github(auth=auth)
+failed=False
+
+try:
+    repo = g.get_repo("oscar-system/Oscar.jl")
+    release = repo.get_latest_release()
+except Exception as e:
+    print(e)
+    print("Network access failed! Falling back to default date and version!")
+    failed = True
+    dt = datetime(1970, 1, 1)
+    version = '0.0.0'
+
+if not failed:
+    dt = release.created_at
+    version = release.title[1:]
+
+releasestring = f"version: '{version}'\nyear: '{dt.year}'\nmonth: '{dt.month}'\nday: '{dt.day}'\ndate: {dt.date()}\n"
+
+if os.getcwd().split('/')[-1] == 'etc':
+    releasefilepath = '../_data/release.yml'
+else:
+    releasefilepath = "_data/release.yml"
+
+with open(releasefilepath, 'w') as releasefile:
+    releasefile.write(releasestring)

--- a/etc/update.sh
+++ b/etc/update.sh
@@ -15,24 +15,17 @@ bundle config set --local path 'vendor/bundle'
 bundle install
 
 # get tutorial status
-statusurl=$(curl -SsL --retry 5 "https://api.github.com/repos/oscar-system/TutorialTesterforOscar/actions/workflows/CI.yml/runs?per_page=1" | jq  '.workflow_runs[0].jobs_url' | sed 's/"//g')
-curl -SsL --retry 5 $statusurl | jq '.["jobs"][1:] | .[] | .name+":"+.conclusion' | sed 's/^.*\s.*\s.*\s//' | sed 's/):/: /' | sed s'/"$//' > _data/examples_status.yml
+echo "Getting tutorial status....."
+./etc/tutorial_status.py
+echo "Done!"
 # get tutorial last modified dates
-cd etc
-python3 update-dates.py
-cd ..
+echo "Getting tutorial last modified dates......."
+./etc/update-dates.py
+echo "Done!"
 # update version info
-curl -SsL https://api.github.com/repos/oscar-system/Oscar.jl/releases/latest > latest.json
-version=$(jq '.["name"]' latest.json | sed 's/v//')
-date=$(jq '.["created_at"]' latest.json | cut -c2-11)
-year=$(echo $date | tr '-' ' ' | awk '{print $1}')
-month=$(echo $date | tr '-' ' ' | awk '{print $2}')
-day=$(echo $date | tr '-' ' ' | awk '{print $3}')
-echo "version: $version" > _data/release.yml
-echo "year: \"$year\"" >> _data/release.yml
-echo "month: \"$month\"" >> _data/release.yml
-echo "day: \"$day\"" >> _data/release.yml
-echo "date: \"$year-$month-$day\"" >> _data/release.yml
-rm latest.json
+echo "Getting version info......."
+./etc/update-latest-release.py
+echo "Done!"
 # run jekyll
-bundle exec jekyll build --config _config.yml,_config_production.yml -d /srv/www/www-mathe-oscar/data/http
+echo "Running jekyl......."
+bundle exec jekyll build --config _config.yml,_config_production.yml # -d /srv/www/www-mathe-oscar/data/http


### PR DESCRIPTION
Rewrites all my clever curls into more standard python/PyGithub, with try/catch blocks for all network requests. This should fail gracefully the next time there is a network error, and prevent more symptoms prompting #485