### PR TITLE
Fix invalid Jekyll markdown

### DIFF
--- a/credits/Citing-OSCAR.md
+++ b/credits/Citing-OSCAR.md
@@ -22,7 +22,7 @@ If you are using **BibTeX**, you can use the following BibTeX entries:
 @misc{OSCAR,
   key          = {OSCAR},
   organization = {The OSCAR Team},
-  title        = {{OSCAR} -- {O}pen {S}ource {C}omputer {A}lgebra {R}esearch system, {V}ersion {{ site.data.release.version }}},
+  title        = {O{SCAR} -- {O}pen {S}ource {C}omputer {A}lgebra {R}esearch system, {V}ersion {{ site.data.release.version }}},
   year         = { {{- site.data.release.year }}},
   url          = {https://www.oscar-system.org},
 }


### PR DESCRIPTION
Unfortunately PR #507 by @lgoettgens broke the website as we now got this error:
```
/Users/mhorn/Projekte/OSCAR/oscar-website/vendor/bundle/ruby/3.4.0/gems/liquid-4.0.4/lib/liquid/block_body.rb:136:in 'Liquid::BlockBody#raise_missing_variable_terminator': Liquid syntax error (line 20): Variable '{{OSCAR}' was not properly terminated with regexp: /\}\}/ (Liquid::SyntaxError)
```

TODO: we should have a working CI detect that kind of issue!