### PR TITLE
Additional redirect for credits and related questions

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -19,5 +19,6 @@ RedirectMatch temp ^/getting-started/tutorials/(.*) https://www.oscar-system.org
 RedirectMatch temp ^/getting-started/documentation/(.*) https://www.oscar-system.org/documentation/$1
 RedirectMatch temp ^/community/(.*) https://www.oscar-system.org/contact-and-support/$1
 RedirectMatch permanent ^/credits/$ https://www.oscar-system.org/credits/software-credits/
+RedirectMatch permanent ^/credits$ https://www.oscar-system.org/credits/software-credits/
 RedirectMatch permanent ^/contributors/$ https://www.oscar-system.org/credits/contributors/
 RedirectMatch permanent ^/contributors$ https://www.oscar-system.org/credits/contributors/

--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -40,10 +40,10 @@
 - title: "Credits"
   url: "/credits/"
   submenu:
+    - title: "Software"
+      url: "/credits/software-credits/"  
     - title: "People"
       url: "/credits/contributors/"
-    - title: "Software"
-      url: "/credits/software-credits/"
     - title: "Bibliography"
       url: "/credits/bibliography/"
     - title: "Citing OSCAR"

--- a/credits/index.md
+++ b/credits/index.md
@@ -3,7 +3,7 @@ layout: page
 title: Credits and Citations
 ---
 
-- [Contributors]({{site.baseurl }}/credits/contributors/) – A list of OSCAR PIs, active members, and past contributors.  
 - [Software Credits]({{site.baseurl }}/credits/software-credits/) – The software projects OSCAR is built upon.  
+- [Contributors]({{site.baseurl }}/credits/contributors/) – A list of OSCAR PIs, active members, and past contributors.  
 - [Citations]({{site.baseurl }}/credits/bibliography/) – Research papers that cite OSCAR.  
 - [How to Cite OSCAR]({{site.baseurl }}/credits/Citing-OSCAR/) – Guidelines for citing OSCAR in your work.  


### PR DESCRIPTION
As requested by @fingolfin in https://github.com/oscar-system/oscar-website/pull/519, we could add another redirect for credits (without backslash). This is the one-line change in this PR.

This touches on https://github.com/oscar-system/oscar-website/issues/517. To understand this issue, please go to `https://www.oscar-system.org/` and `click` on credits in the sidebar. I then see the following:

![Picture2](https://github.com/user-attachments/assets/544dc1b4-00d9-42f5-9875-37d942145d92)

I.e. the click on credits immediately takes me to the software credits. This is not in tandem with the side layout and setup for the following reasons:
1. If clicking on credits takes us to a submenu immediately, then probably it should be the very first submenu and not the second, right? This can for instance be fixed by changing the order of the submenus. (On second thought, adjusting the credit redirect to take us to the people credits is not a good idea. Likely, credits is used in many other places - say the OSCAR documentation - to give credits to the underlying software that OSCAR build upon.)

2. We have a dedicated credits page, which is not accessible due to our redirects (or so I believe). When running jekyll on my computer, I can access it. Here is what this page looks like:

![Picture](https://github.com/user-attachments/assets/11de3296-b6ca-4316-9542-d257f8527b8a)