### PR TITLE
Changes to make `Installation` on the sidebar be bold 

### DIFF
--- a/_data/sidebar.yml
+++ b/_data/sidebar.yml
@@ -1,6 +1,3 @@
-- title: "Home"
-  url: "/"
-
 # SPACER
 - spacer: true
 

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -9,12 +9,16 @@
     </div>
 
     <nav class="sidebar-nav">
-
+      <div class="sidebar-nav-item {% if page.url == '/' %}active{% endif %}">
+        <a href="{{site.baseurl}}/" class="sidebar-nav-link">
+          Home
+        </a>
+    </div>
       {% for item in site.data.sidebar %}
         {% if item.spacer %}
           <div style="margin-top: 0.7em;"></div>
         {% elsif item.submenu %}
-        <div class="sidebar-nav-item {% if page.url == item.url %}active{% endif %}">
+        <div class="sidebar-nav-item {% if page.url contains item.url %}active{% endif %}">
           <details {% if page.url contains item.url %}open{% endif %}>
             <summary class="nav">
               <a href="{{ site.baseurl}}{{ item.url }}" class="sidebar-nav-link">
@@ -34,7 +38,7 @@
           </details>
         </div>
           {% else %}
-          <div class="sidebar-nav-item {% if page.url == item.url %}active{% endif %}">
+          <div class="sidebar-nav-item {% if page.url contains item.url %}active{% endif %}">
           <a href="{{ site.baseurl}}{{ item.url }}" class="sidebar-nav-link">
             {{ item.title }}
           </a>

--- a/install-generic.md
+++ b/install-generic.md
@@ -1,25 +1,26 @@
 ---
 layout: page
+permalink: /install/generic
 ---
 
 <div class="platform-tabs">
   <input type="radio" id="mac" name="platform">
-  <label for="mac" onclick="window.location.href='{{site.baseurl}}/install-mac/'">Mac</label>
+  <label for="mac" onclick="window.location.href='{{site.baseurl}}/install/mac/'">Mac</label>
 
   <input type="radio" id="windows" name="platform">
-  <label for="windows" onclick="window.location.href='{{site.baseurl}}/install-win/'">Windows</label>
+  <label for="windows" onclick="window.location.href='{{site.baseurl}}/install/win/'">Windows</label>
 
   <input type="radio" id="linux" name="platform">
-  <label for="linux" onclick="window.location.href='{{site.baseurl}}/install-linux/'">Linux</label>
+  <label for="linux" onclick="window.location.href='{{site.baseurl}}/install/linux/'">Linux</label>
 
   <input type="radio" id="other" name="platform" checked>
-  <label for="other" onclick="window.location.href='{{site.baseurl}}/install-generic/'">Other</label>
+  <label for="other" onclick="window.location.href='{{site.baseurl}}/install/generic/'">Other</label>
 </div>
 
 
 # Installing OSCAR {{ site.data.release.version }}
 
-The latest stable release, **OSCAR v{{ site.data.release.version }}**, is officially supported on [**Windows**]({{site.baseurl}}/install-win/), [**macOS**]({{site.baseurl}}/install-mac/), and [**Linux (Debian, Ubuntu, Fedora)**]({{site.baseurl}}/install-linux/).
+The latest stable release, **OSCAR v{{ site.data.release.version }}**, is officially supported on [**Windows**]({{site.baseurl}}/install/win/), [**macOS**]({{site.baseurl}}/install/mac/), and [**Linux (Debian, Ubuntu, Fedora)**]({{site.baseurl}}/install/linux/).
 
 If you are using a **different operating system**, we **do not provide support** and **cannot guarantee compatibility**. However, if you still wish to try installing OSCAR, you will need:
 - **[GNU Make](https://www.gnu.org/software/make/)**

--- a/install-linux.md
+++ b/install-linux.md
@@ -1,19 +1,20 @@
 ---
 layout: page
+permalink: /install/linux/
 ---
 
 <div class="platform-tabs">
   <input type="radio" id="mac" name="platform">
-  <label for="mac" onclick="window.location.href='{{site.baseurl}}/install-mac/'">Mac</label>
+  <label for="mac" onclick="window.location.href='{{site.baseurl}}/install/mac/'">Mac</label>
 
   <input type="radio" id="windows" name="platform">
-  <label for="windows" onclick="window.location.href='{{site.baseurl}}/install-win/'">Windows</label>
+  <label for="windows" onclick="window.location.href='{{site.baseurl}}/install/win/'">Windows</label>
 
   <input type="radio" id="linux" name="platform" checked>
-  <label for="linux" onclick="window.location.href='{{site.baseurl}}/install-linux/'">Linux</label>
+  <label for="linux" onclick="window.location.href='{{site.baseurl}}/install/linux/'">Linux</label>
 
   <input type="radio" id="other" name="platform">
-  <label for="other" onclick="window.location.href='{{site.baseurl}}/install-generic/'">Other</label>
+  <label for="other" onclick="window.location.href='{{site.baseurl}}/install/generic/'">Other</label>
 </div>
 
 

--- a/install-mac.md
+++ b/install-mac.md
@@ -1,19 +1,20 @@
 ---
 layout: page
+permalink: /install/mac/
 ---
 
 <div class="platform-tabs">
   <input type="radio" id="mac" name="platform" checked>
-  <label for="mac" onclick="window.location.href='{{site.baseurl}}/install-mac/'">Mac</label>
+  <label for="mac" onclick="window.location.href='{{site.baseurl}}/install/mac/'">Mac</label>
 
   <input type="radio" id="windows" name="platform">
-  <label for="windows" onclick="window.location.href='{{site.baseurl}}/install-win/'">Windows</label>
+  <label for="windows" onclick="window.location.href='{{site.baseurl}}/install/win/'">Windows</label>
 
   <input type="radio" id="linux" name="platform">
-  <label for="linux" onclick="window.location.href='{{site.baseurl}}/install-linux/'">Linux</label>
+  <label for="linux" onclick="window.location.href='{{site.baseurl}}/install/linux/'">Linux</label>
 
   <input type="radio" id="other" name="platform">
-  <label for="other" onclick="window.location.href='{{site.baseurl}}/install-generic/'">Other</label>
+  <label for="other" onclick="window.location.href='{{site.baseurl}}/install/generic/'">Other</label>
 </div>
 
 

--- a/install-win.md
+++ b/install-win.md
@@ -1,19 +1,20 @@
 ---
 layout: page
+permalink: /install/win
 ---
 
 <div class="platform-tabs">
   <input type="radio" id="mac" name="platform">
-  <label for="mac" onclick="window.location.href='{{site.baseurl}}/install-mac/'">Mac</label>
+  <label for="mac" onclick="window.location.href='{{site.baseurl}}/install/mac/'">Mac</label>
 
   <input type="radio" id="windows" name="platform" checked>
-  <label for="windows" onclick="window.location.href='{{site.baseurl}}/install-win/'">Windows</label>
+  <label for="windows" onclick="window.location.href='{{site.baseurl}}/install/win/'">Windows</label>
 
   <input type="radio" id="linux" name="platform">
-  <label for="linux" onclick="window.location.href='{{site.baseurl}}/install-linux/'">Linux</label>
+  <label for="linux" onclick="window.location.href='{{site.baseurl}}/install/linux/'">Linux</label>
 
   <input type="radio" id="other" name="platform">
-  <label for="other" onclick="window.location.href='{{site.baseurl}}/install-generic/'">Other</label>
+  <label for="other" onclick="window.location.href='{{site.baseurl}}/install/generic/'">Other</label>
 </div>
 
 

--- a/install.md
+++ b/install.md
@@ -7,15 +7,15 @@ title: Installation Instructions
     const nowurl = window.location.href
     const target = nowurl.slice(nowurl.indexOf('#'))
     if (navigator.userAgent.includes("Linux")){
-        window.location.replace("{{site.baseurl}}/install-linux"+target);
+        window.location.replace("{{site.baseurl}}/install/linux"+target);
     }
     else if (navigator.userAgent.includes("Win")){
-        window.location.replace("{{site.baseurl}}/install-win"+target);
+        window.location.replace("{{site.baseurl}}/install/win"+target);
     }
     else if (navigator.userAgent.includes("Macintosh")){
-        window.location.replace("{{site.baseurl}}/install-mac"+target);
+        window.location.replace("{{site.baseurl}}/install/mac"+target);
     }
     else {
-        window.location.replace("{{site.baseurl}}/install-generic"+target);
+        window.location.replace("{{site.baseurl}}/install/generic"+target);
     }
 </script>


### PR DESCRIPTION
Changes to make `Installation` on the sidebar be bold  when viewing an installation page.

This involves changing many URLS from `install-platform` to `install/platform` , and might require updating some links in other places in the Oscar universe like documentation, etc. (Although, we really shouldn't be linking to platform specific install pages from outside the website itself, no ?)

This change also hard codes `home` to be in the sidebar.html, and not generated from sidebar.yml. This is because the logic which makes the active sidebar item appear bold checks for "if item URL occurs in current page URL". Since home is `/`, and `/` appears in every URL, this would make home be bold all the time. Instead, for just that one we check "if item URL is baseURL".

Fixes #522 