### PR TITLE
Hotfix: add trailing slash to fix windows install page URL

### DIFF
--- a/install-win.md
+++ b/install-win.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-permalink: /install/win
+permalink: /install/win/
 ---
 
 <div class="platform-tabs">


### PR DESCRIPTION
Fixes a problem raised in slack, where `https://oscar-system.org/install/win/` doesn't work, but `https://oscar-system.org/install/win` does work. (Now, both should work)

I am merging this already because currently people get a 404 when trying to look at windows install instructions, but @HereAround feel free to revert this if you think this is wrong.