### PR TITLE
Overhaul software credits

### DIFF
--- a/credits/software-credits.md
+++ b/credits/software-credits.md
@@ -47,11 +47,13 @@ used_software:
 
     - name: AbstractAlgebra
       website: https://github.com/Nemocas/AbstractAlgebra.jl
-      
+
     - name: msolve
       website: https://msolve.lip6.fr/
 
-used_software_technical:
+    - name: cohomCalg
+      website: https://github.com/BenjaminJurke/cohomCalg
+
     - name: CxxWrap.jl
       website: https://github.com/JuliaInterop/CxxWrap.jl
 
@@ -59,9 +61,7 @@ used_software_technical:
       website: https://www.julialang.org
 ---
 
-### Mathematical software
-
-The OSCAR project is based on the following mathematical software:
+OSCAR relies on many software packages. For a complete and up-to-date list of dependencies, please see the [Project.toml file](https://github.com/oscar-system/Oscar.jl/blob/master/Project.toml) in the OSCAR GitHub repository. The following are some of them:
 
 {% assign entries = page.used_software | sort_natural:"name" %}
 <ul class="software_credits_list">
@@ -74,22 +74,12 @@ The OSCAR project is based on the following mathematical software:
 {% endfor %}
 </ul>
 
-### Technical software
-
-The following software is used as technical components in the OSCAR project:
-
-{% assign entries = page.used_software_technical | sort_natural:"name" %}
-<ul>
-{% for p in entries %}
-  <li>
-    <a href="{{ p.website }}">
-    <strong>{{ p.name }}</strong>
-    </a>
-  </li>
-{% endfor %}
-</ul>
-
-
 ### MaRDI
 
 The [Mathematical Research Data Initiative](https://www.mardi4nfdi.de/about/mission) (MaRDI), is a German consortium dedicated to setting guidelines and developing software for findability, accessibility, interoperability, and reuse of mathematical research data. OSCAR's serialization employs the **mrdi** file format, the specifications of which can be found on [zenodo](https://zenodo.org/records/12723387). More details are available in [this article](https://link.springer.com/chapter/10.1007/978-3-031-64529-7_25) and the [OSCAR documentation](https://docs.oscar-system.org/stable/General/serialization/).
+
+### LEAN meets OSCAR
+
+The [LEAN proof assistant](https://lean-lang.org/) is a formal system for writing and verifying mathematical proofs using a computer. While OSCAR is designed to perform concrete symbolic computations in areas such as algebra and geometry, LEAN is tailored for the formalization and verification of abstract mathematical reasoning.
+
+An initial connection between these two systems has been explored in the meeting [LEAN meets MaRDI and OSCAR (Berlin, December 2024)](https://polymake.org/doku.php/workshops/lean_workshop1224) and most notably in the [Lean-Oscar](https://github.com/todbeibrot/Lean-Oscar) repository, originally created by [Cedric Holle](https://github.com/todbeibrot). This proof-of-principle demonstrates how OSCAR can support formal proofs in LEAN. Such an interaction opens up promising avenues for collaboration and research, allowing mathematicians to bridge the gap between rigorous computation and rigorous proof.


### PR DESCRIPTION
This PR aims to close the following issues:
* https://github.com/oscar-system/oscar-website/issues/532
* https://github.com/oscar-system/oscar-website/issues/525

Steps taken:
* Mention that the list of cited software is likely incomplete, and that the complete list is available in the Project.toml file. Then continue with combined list of mathematical and technical software.
* cohomCalg added to list of OSCAR software credits.
* Add paragraph on interaction between LEAN and OSCAR.

@fingolfin You wrote in https://github.com/oscar-system/oscar-website/issues/532 that we should likely mention `GAP.jl`, `Singular.jl` and `Polymake.jl`. On closer inspection, I notice that we mention `GAP`, `Singular` and `Polymake`. I do understand the distinction between say `GAP` and `GAP.jl` but am uncertain if truly both should be listed. Please let me know your thoughts.

Similarly, I am trying to gauge how the Singular Factory should be cited in the OSCAR software credits. Maybe exactly how it is being done right now, but I cannot but wonder about its current status @hannes14. What is the status of https://www.singular.uni-kl.de/ftp/pub/Math/Singular/Factory/README? Is it still being developed? By Martin Lee? Or by others? When was it last modified? Or has this package been absorbed into Singular and is no longer considered an independent subsystem?