### PR TITLE
Trim requirements file

### DIFF
--- a/etc/requirements.txt
+++ b/etc/requirements.txt
@@ -1,15 +1,3 @@
-certifi==2025.4.26
-cffi==1.17.1
-charset-normalizer==3.4.2
-cryptography==45.0.3
-Deprecated==1.2.18
-idna==3.10
-pycparser==2.22
 PyGithub==2.6.1
-PyJWT==2.10.1
-PyNaCl==1.5.0
 PyYAML==6.0.2
 requests==2.32.4
-typing_extensions==4.13.2
-urllib3==2.4.0
-wrapt==1.17.2

--- a/etc/update.sh
+++ b/etc/update.sh
@@ -21,6 +21,11 @@ fi
 . .venv/bin/activate
 
 # install requirements for the python scripts
+OUTDATED_PACKAGES_LIST=$(pip list --outdated --format json | jq -r '.[].name')
+if [ -n "$OUTDATED_PACKAGES_LIST" ]
+then
+	python3 -m pip install --upgrade "$OUTDATED_PACKAGES_LIST"
+fi
 python3 -m pip install --upgrade -r etc/requirements.txt
 
 # get tutorial status


### PR DESCRIPTION
Trim requirements file to not pin automatic / recursive imports to a specific version.

All libraries we explicitly import are now specified in the `requirements.txt` file, and each package then specifies its own version constraints.

This will decrease the number of PRs like #530 , and these libraries will be auto updated (within the constraints we require) whenever the script is run.