### PR TITLE
Update action for update-contributors

### DIFF
--- a/.github/workflows/test-contributer-script.yml
+++ b/.github/workflows/test-contributer-script.yml
@@ -1,0 +1,37 @@
+name: Contributors Update Script
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run-contributors-update-script:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v5
+      
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Install Python deps
+      run: |
+        python -m pip install --upgrade pip
+        pip install PyGithub pyyaml requests
+
+    - name: Run update-contributors script
+      env:
+        API_KEY: ${{secrets.API_KEY}}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PYTHONUNBUFFERED: "1"
+      run: |
+        cd etc
+        python3 update-contributors.py
+        cd ..
+

--- a/.github/workflows/update-contrib.yml
+++ b/.github/workflows/update-contrib.yml
@@ -1,55 +1,54 @@
 name: Update Contributors
 
-# Schedule: Runs at midnight on the first day of each month
 on:
   push:
-    branches:
-      - gh-pages
+    branches: [gh-pages]
   workflow_dispatch:
   schedule:
-    - cron: '0 0 1 * *'  # At 00:00 UTC on the 1st of every month
+    - cron: '0 0 1 * *'
 
-# only run at most one instances of this workflow at a time for each branch
-# resp. tag. Starting a new one cancels previously running ones.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   update-contributors:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
-    # Checkout the repository
     - name: Checkout Repository
       uses: actions/checkout@v5
       
-    # Run the update script
-    - name: Setup venv and install pyyaml
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Install Python deps
       run: |
-        pip install pyyaml requests
+        python -m pip install --upgrade pip
+        pip install PyGithub pyyaml requests
 
     - name: Run update-contributors script
       env:
         API_KEY: ${{secrets.API_KEY}}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PYTHONUNBUFFERED: "1"
       run: |
         cd etc
-        python update-contributors.py
+        python3 update-contributors.py
         cd ..
 
-    # Configure Git for the PR
     - name: Set up Git
       run: |
         git config user.name "contributor-list[bot]"
         git config user.email "contributor-list[bot]@users.noreply.github.com"
 
-    # Commit the changes
     - name: Commit Changes
       run: |
         git add _data/people_list.yml
         git commit -m "Update contributors on $(date +'%Y-%m-%d')" || echo "Nothing to commit!"
 
-    # Create a pull request
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v7
       with:

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -42,7 +42,7 @@ newpersonlist = []
 github_newusers = []
 github_userlist = []
 github_username = '__notfound__'
-API_KEY = os.getenv("API_KEY") # TODO: rename to whatever is the right env var
+API_KEY = (os.getenv("API_KEY") or os.getenv("GITHUB_TOKEN") or "").strip()
 summarystring = ""
 # grab currently active devs
 if not os.path.isdir("repos"):


### PR DESCRIPTION
* Add CI action which runs the contributor update on PRs
* Keep separate action on merge/schedule, so it can open a separate PR.
* Use latest ubuntu version instead of 22.04
* Set up Python more efficiently