### PR TITLE
Back to two workflows for contributor script + latest python version for all CI workflows

### DIFF
--- a/.github/workflows/latest_replease.yml
+++ b/.github/workflows/latest_replease.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.x"
 
       - name: Install Python deps
         run: |

--- a/.github/workflows/test-contributer-script.yml
+++ b/.github/workflows/test-contributer-script.yml
@@ -1,24 +1,20 @@
-name: Update Contributors
+name: Contributors Update Script
 
 on:
-  push:
-    branches: [gh-pages]
-  workflow_dispatch:
-  schedule:
-    - cron: '0 0 1 * *'
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  update-contributors:
+  run-contributors-update-script:
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v5
-
+      
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -39,12 +35,8 @@ jobs:
         python3 update-contributors.py
         cd ..
 
-    - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v7
-      with:
-        commit-message: "Update contributors on ${{ github.run_started_at[0:10] }}"
-        branch: update-contributors
-        delete-branch: true
-        title: "Update contributors"
-        body-path: summary.txt
-        base: gh-pages
+    - name: Show summary.txt
+      run: |
+        echo "::group::summary.txt"
+        sed -n '1,200p' summary.txt || echo "summary.txt not found"
+        echo "::endgroup::"

--- a/.github/workflows/tutorial-last-modified-dates.yml
+++ b/.github/workflows/tutorial-last-modified-dates.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.x"
 
       - name: Install Python deps
         run: |

--- a/.github/workflows/tutorial_status.yml
+++ b/.github/workflows/tutorial_status.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.x"
 
       - name: Install Python deps
         run: |


### PR DESCRIPTION
* Somehow, my attempt to merge two workflows (on PR just test the contributor script, and on schedule/merge to gh-pages open a PR) failed, in that the action was then no longer run in PRs. So I revert this here, returning to two separate actions. It is code duplication for sure. In the future, we might be able to figure out how to merge.
* Use latest python 3.x version in all runs.