### PR TITLE
Refactor contributor script to next level

### DIFF
--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -67,7 +67,28 @@ def custom_sort_function(item):
 
 
 ##########################################
-# 2. Read information from people_list.yml
+# 2. Global variables
+##########################################
+
+# Step 3: The information on contributors, that is currently saved in PEOPLE_LIST_FILE.
+#current_contributors
+
+# Step 4: People come with alias emails. This dict will tell us the owner of a given email, provided our PEOPLE_LIST_FILE knows about this
+email_owner = {}  # lowercased email -> person dict
+
+# Step 4: Same as email_owner, but with name alias instead
+name_owner  = {}  # normalized name -> person dict
+
+# Step 5: A dict, in which we store information about the current authors and coauthors
+aggregate = {}      # key -> {'name','email','is_author','known_github','repos': set()}
+
+# Step 5: This string will collect warnings encountered during execution
+summarystring = ""
+
+
+
+##########################################
+# 3. Read information from people_list.yml
 ##########################################
 
 try:
@@ -83,16 +104,11 @@ except yaml.YAMLError as e:
 for person in current_contributors:
     person.setdefault("repos", [])
 
-current_github_usernames = [person["github"] for person in current_contributors if "github" in person]
-
 
 
 ##########################################
-# 3. Build fast alias lookup
+# 4. Build fast alias lookup
 ##########################################
-
-email_owner = {}  # lowercased email -> person dict
-name_owner  = {}  # normalized name -> person dict
 
 def _norm_name(s: str) -> str:
     return " ".join((s or "").split()).lower()
@@ -130,35 +146,14 @@ def _person_key(name: str, email: str):
 
 
 ##########################################
-# 4. Collect (co)authors for each repo
+# 5. Helper: Progress git log
 ##########################################
 
-# 4.1 Change into REPOS_DIR
-if not os.path.isdir(REPOS_DIR):
-    os.mkdir(REPOS_DIR)
-os.chdir(REPOS_DIR)
+def process_log_into_aggregate(res: str, repo: str) -> None:
 
-# 4.2 Run over repos to aggreate authors and coauthors
-summarystring = ""
-aggregate = {}      # key -> {'name','email','is_author','known_github','repos': set()}
-for repo in REPO_LIST:
+    global summarystring, aggregate, email_owner, name_owner
 
-    print(f"Processing {repo}...")
-    repo_path = repo.split('/')[-1]
-    if not os.path.isdir(repo_path):
-        subprocess.run(["git", "clone", f"https://github.com/{repo}"], check=True)
-    os.chdir(repo_path)
-    subprocess.run(["git", "fetch", "--all"], check=True)
-    subprocess.run(["git", "pull"], check=True)
-    log_cmd = ["git", "log", "--use-mailmap", GIT_LOG_SINCE, GIT_LOG_FORMAT_1]
-    res = subprocess.run(log_cmd, capture_output=True, text=True, encoding="utf-8", errors="replace")
-    os.chdir("..")
-    if res.returncode != 0:
-        print("DEBUG git log failed; stderr:", res.stderr.strip())
-        sys.exit(1)
-    
-    # 4.5 Process the log and update aggregate accordingly
-    for raw in res.stdout.splitlines():
+    for raw in res.splitlines():
 
         # Prepare the line and skip if empty
         line = raw.strip()
@@ -170,7 +165,7 @@ for repo in REPO_LIST:
         if line.lower().startswith("co-authored-by:"):
             line = line.split(":", 1)[1].strip()
             is_author = False
-
+        
         # Skip bots and non-address lines
         lower_line = line.lower()
         if any(b in lower_line for b in BOT_TOKENS):
@@ -231,7 +226,32 @@ for repo in REPO_LIST:
 
 
 ##########################################
-# 5. Processing further
+# 6. Find (co)authors of all repos
+##########################################
+
+if not os.path.isdir(REPOS_DIR):
+    os.mkdir(REPOS_DIR)
+os.chdir(REPOS_DIR)
+for repo in REPO_LIST:
+    print(f"Processing {repo}...")
+    repo_path = repo.split('/')[-1]
+    if not os.path.isdir(repo_path):
+        subprocess.run(["git", "clone", f"https://github.com/{repo}"], check=True)
+    os.chdir(repo_path)
+    subprocess.run(["git", "fetch", "--all"], check=True)
+    subprocess.run(["git", "pull"], check=True)
+    log_cmd = ["git", "log", "--use-mailmap", GIT_LOG_SINCE, GIT_LOG_FORMAT_1]
+    res = subprocess.run(log_cmd, capture_output=True, text=True, encoding="utf-8", errors="replace")
+    os.chdir("..")
+    if res.returncode != 0:
+        print("DEBUG git log failed; stderr:", res.stderr.strip())
+        sys.exit(1)
+    process_log_into_aggregate(res.stdout, repo)
+
+
+
+##########################################
+# 7. Processing further
 ##########################################
 
 unresolved = []
@@ -239,6 +259,7 @@ newList = []
 newpersonlist = []
 github_newusers = []
 github_userlist = []
+current_github_usernames = [person["github"] for person in current_contributors if "github" in person]
 for key, rec in aggregate.items():
     name = rec["name"]
     email = rec["email"]
@@ -275,7 +296,7 @@ for rec in unresolved:
 
 
 ##########################################
-# 6. Sort as new, retired, active
+# 8. Sort as new, retired, active
 ##########################################
 
 newCoauthorList = []
@@ -324,7 +345,7 @@ sortedcurrent_contributors = sorted(current_contributors, key= lambda d: d['name
 
 
 ##########################################
-# 7. Save the findings
+# 9. Save the findings
 ##########################################
 
 # save yml to *NEW* file

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -77,28 +77,18 @@ SORT_WEIGHT = {
 # 2. Globals (runtime state; mutated)
 ##########################################
 
-# Contributor lists
-current_contributors = []  # list[dict]
+# Contributor lists and index structures
+current_contributors = []  # loaded from YAML
+email_owner = {}           # lowercased email → person dict
+name_owner = {}            # normalized name → person dict
 
-# Alias indices built from current_contributors
-email_owner = {}   # lowercased email -> person dict
-name_owner  = {}   # normalized name  -> person dict
-
-# Aggregate across repos: key -> {'name','email','is_author','known_github','repos': set()}
+# Aggregation state
 aggregate = {}
-
-# Collected notes (maybe use a list to avoid 'global' rebinding of strings)
 summarystring = ""
 
-# Once we aggregated the current contributors, we fill them into the following buckets
-active_contributors = []            # references to active current_contributors entries
-new_contributors = []               # data of new (co)authors in unified schema: {"name","email","repos","github|None","commit_hash|None"}
-_seen_current = set()               # track object identity for computation of retired contributors
-retired_contributors = []           # references to retired current_contributors entries
-_prev_status = {}                   # Status of people before we match them against aggregate and thus update their status
-newly_retired_names = []            # The list of the names of people who retired recently
-sorted_current_contributors = []    # the current contributors - new active, retired, PI sorted by name
-ordered_people = []                 # final list of sorted current contributors, with each field sorted by our custom design in SORT_WEIGHT
+# Classification buckets
+active_contributors, new_contributors, retired_contributors = [], [], []
+_seen_current = set()
 
 
 
@@ -242,10 +232,7 @@ for repo in REPO_LIST:
         subprocess.run(["git", "-C", repo_dir, "pull"], check=True)
     res = subprocess.run(
         ["git", "-C", repo_dir, "log", "--use-mailmap", GIT_LOG_SINCE, GIT_LOG_FORMAT_1],
-        capture_output=True, text=True, encoding="utf-8", errors="replace")
-    if res.returncode != 0:
-        print("git log failed; stderr:", res.stderr.strip())
-        sys.exit(1)
+        check=True, capture_output=True, text=True, encoding="utf-8", errors="replace")
     process_log_into_aggregate(res.stdout, repo)
 
 
@@ -261,9 +248,7 @@ def resolve_github_via_commit(email: str, repos: list[str]) -> str | None:
     for r in repos:
         res = subprocess.run(
             ["git", "-C", _repo_dir(r), "log", GIT_LOG_SINCE, f"--author={email}", "--format=%H", "-n", "1"],
-            capture_output=True, text=True, encoding="utf-8")
-        if res.returncode != 0:
-            continue
+            check=True, capture_output=True, text=True, encoding="utf-8")
         commit_hash = (res.stdout or "").strip()
         if not commit_hash:
             continue  # no direct authored commit in this repo (could be co-author only)
@@ -282,9 +267,7 @@ def find_coauthor_commit(name: str, email: str, repos: list[str]) -> str:
     for r in repos:
         res = subprocess.run(
             ["git", "-C", _repo_dir(r), "log", GIT_LOG_SINCE, GIT_LOG_FORMAT_2],
-            capture_output=True, text=True, encoding="utf-8")
-        if res.returncode != 0:
-            continue
+            check=True, capture_output=True, text=True, encoding="utf-8")
         for line in res.stdout.splitlines():
             low = line.lower()
             if not any(t in low for t in targets):
@@ -311,7 +294,7 @@ for key, rec in aggregate.items():
     if user:
         # Merge repos into existing user (preserve order, avoid dups)
         have = set(user["repos"])
-        user["repos"].extend(r for r in repos if r not in have)
+        user["repos"].extend([r for r in repos if r not in have])
 
         # If we just learned their GitHub, store it and index it
         if gh and not user.get("github"):
@@ -365,10 +348,7 @@ for p in current_contributors:
 
 # Final order by surname, then tidy field order
 people_sorted = sorted(current_contributors, key=lambda d: (d.get("name", "").split()[-1], d.get("name", "")))
-def custom_sort_function(item):
-    key, _ = item
-    return SORT_WEIGHT.get(key, 999)
-ordered_people = [dict(sorted(p.items(), key=custom_sort_function)) for p in people_sorted]
+ordered_people = [dict(sorted(p.items(), key=lambda kv: SORT_WEIGHT.get(kv[0], 999))) for p in people_sorted]
 
 # Write new content to PEOPLE_LIST_FILE
 class MyDumper(yaml.SafeDumper):

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -119,7 +119,7 @@ for p in current_contributors:
     if p.get("email"):
         emails.append(p["email"])
     if p.get("aka_email"):
-        emails.extend(p["aka_email"] or [])
+        emails.extend(p["aka_email"])
     for e in emails:
         email_owner[e.lower()] = p
 
@@ -128,7 +128,9 @@ for p in current_contributors:
     if p.get("name"):
         names.append(p["name"])
     if p.get("aka"):
-        names.extend(p["aka"] or [])
+        names.extend(p["aka"])
+    if p.get("github"):
+        names.append(p["github"])
     for n in names:
         name_owner[_norm_name(n)] = p
 
@@ -251,96 +253,173 @@ for repo in REPO_LIST:
 
 
 ##########################################
-# 7. Processing further
+# 7. Post-aggregation enrichment & updates
 ##########################################
 
-unresolved = []
-newList = []
-newpersonlist = []
-github_newusers = []
-github_userlist = []
-current_github_usernames = [person["github"] for person in current_contributors if "github" in person]
-for key, rec in aggregate.items():
+def resolve_github_via_commit(email: str, repos: list[str]) -> str | None:
+    """Try to resolve a GitHub login by finding one authored commit for this email."""
+    if not email:
+        return None
+    for r in repos:
+        repo_path = r.split('/')[-1]
+        # Find a representative commit authored by this email
+        p = subprocess.run(
+            ["git", "log", f"--author={email}", "--format=%H", "-n", "1"],
+            cwd=repo_path, capture_output=True, text=True, encoding="utf-8"
+        )
+        commit_hash = (p.stdout or "").strip()
+        if not commit_hash:
+            continue  # no direct authored commit in this repo (could be co-author only)
+        url = f"https://api.github.com/repos/{r}/commits/{commit_hash}"
+        resp = requests.get(url, headers={"Authorization": f"Bearer {API_KEY}"})
+        if resp.status_code != 200:
+            continue
+        j = resp.json()
+        author = j.get("author")
+        if author and author.get("login"):
+            return author["login"]
+    return None
+
+def find_coauthor_commit(name: str, email: str, repos: list[str]) -> tuple[str | None, str | None]:
+    """Find any commit that mentions this person in subject or trailers, return (repo, hash)."""
+    targets = {t for t in (name.lower(), email.lower()) if t}
+    for r in repos:
+        repo_path = r.split('/')[-1]
+        res = subprocess.run(
+            ["git", "log", GIT_LOG_SINCE, GIT_LOG_FORMAT_2],
+            cwd=repo_path, capture_output=True, text=True, encoding="utf-8"
+        )
+        if res.returncode != 0:
+            continue
+        for line in res.stdout.splitlines():
+            low = line.lower()
+            if any(t in low for t in targets):
+                parts = line.split()
+                if parts:
+                    return r, parts[0]
+    return None, None
+
+# Precompute current known GitHub usernames
+current_github_usernames = [p["github"] for p in current_contributors if "github" in p]
+
+# Buckets
+newList = []            # [name, email, github, repos]
+newpersonlist = []      # names for summary
+github_newusers = []    # github handles of new people
+github_userlist = []    # everyone seen as active this run (by github)
+newCoauthorList = []    # [name, email, repo, commit_hash] for unmapped co-authors
+unresolved = []         # aggregate recs without github after all attempts
+
+# 7.1 Resolve GitHub handles where missing, update contributors & build 'newList'
+for rec in aggregate.values():
     name = rec["name"]
     email = rec["email"]
     repos = sorted(rec["repos"])
     gh = rec["known_github"]
 
+    # Try to resolve missing GitHub once, across their repos
+    if not gh:
+        gh = resolve_github_via_commit(email, repos)
+
     if gh:
-        # Known GitHub from YAML
+        # Mark active set
+        if gh not in github_userlist:
+            github_userlist.append(gh)
+
         if gh in current_github_usernames:
-            # existing contributor: just append repos
+            # Existing contributor: append repos
             user = next((it for it in current_contributors if it.get("github") == gh), None)
             if user is not None:
                 for r in repos:
                     if r not in user.setdefault("repos", []):
                         user["repos"].append(r)
         else:
-            # new contributor (known gh from aliases)
+            # New contributor
             newpersonlist.append(name)
             github_newusers.append(gh)
             newList.append([name, email, gh, repos])
-        if gh not in github_userlist:
-            github_userlist.append(gh)
     else:
-        # No GitHub yet — leave for a later step (or future API pass)
+        # Still unresolved — likely co-author or private email
         unresolved.append(rec)
 
-# Optional: note unresolved folks so they don't silently vanish
+# 7.2 For truly unresolved people, create co-author entries with a representative commit hash (optional but helpful)
 for rec in unresolved:
-    summarystring += (
-        f"- Github username not found for {rec['name']} <{rec['email']}>; "
-        f"repos={sorted(rec['repos'])}. Skipping for now.\n"
-    )
+    # If they already exist in YAML (co-author entries without github), we won't add dupes now.
+    # We'll just record one commit hash for context.
+    rrepo, rhash = find_coauthor_commit(rec["name"], rec["email"], sorted(rec["repos"]))
+    if rrepo and rhash:
+        newCoauthorList.append([rec["name"], rec["email"], rrepo, rhash])
+    else:
+        # Breadcrumb in summary so they don't vanish silently
+        summarystring += (
+            f"- No GitHub and no commit hash found for {rec['name']} <{rec['email']}>; "
+            f"repos={sorted(rec['repos'])}. Skipping for now.\n"
+        )
 
 
 
 ##########################################
-# 8. Sort as new, retired, active
+# 8. Compute active/retired/revived and update YAML structure
 ##########################################
 
-newCoauthorList = []
+# Add new contributors to YAML (prefer non-noreply emails, as before)
+np = []
+for name, email, gh, repos in newList:
+    if "users.noreply.github.com" in (email or ""):
+        np.append({"name": name, "github": gh, "status": "active", "repos": repos})
+        summarystring += f"- Email not found for {name} ({gh})..!\n"
+    else:
+        np.append({"name": name, "email": email, "github": gh, "status": "active", "repos": repos})
+current_contributors.extend(np)
 
-# mark active / retired
-# if PI, don't touch them
-os.chdir("..")
+# Add new co-authors (no github) with a commit reference
+np = []
+for name, email, repo, commit_hash in newCoauthorList:
+    np.append({
+        "name": name,
+        "email": email,
+        "status": "active",
+        "comment": f"Co-author of commit {commit_hash}",
+        "repos": [repo],
+    })
+current_contributors.extend(np)
+
+# Determine revive/retire based on github_userlist
 retcount = 0
 revcount = 0
 retpersonlist = []
 revpersonlist = []
-for i in current_contributors:
-    if 'github' not in i:
-        #co authors
+
+for person in current_contributors:
+    if 'github' not in person:
+        # co-authors without github — leave status alone (treated as active)
         continue
-    if i['status']=='pi':
-        continue
-        #don't touch a thing!
-    elif i['github'] in github_userlist:
-        if i['status'] == 'retired':
+    if person.get('status') == 'pi':
+        continue  # never touch PIs
+    gh = person.get('github')
+    if gh in github_userlist:
+        # Active this period
+        if person.get('status') == 'retired':
             revcount += 1
-            revpersonlist.append(i['name'])
-        i['status'] = 'active'
+            revpersonlist.append(person.get('name'))
+        person['status'] = 'active'
     else:
-        if i['status'] == 'active':
+        # Not active this period
+        if person.get('status') == 'active':
             retcount += 1
-            retpersonlist.append(i['name'])
-        i['status'] = 'retired'
+            retpersonlist.append(person.get('name'))
+        person['status'] = 'retired'
 
-np = []
-for i in newList:
-    if "users.noreply.github.com" in i[1]:
-        np.append({"name": i[0], "github": i[2], "status": "active", "repos": i[3]})
-        summarystring += f"- Email not found for {i[0]} ({i[2]})..!\n"
-    else:
-        np.append({"name": i[0], "email": i[1], "github": i[2], "status": "active", "repos": i[3]})
-current_contributors.extend(np)
+# Normalize & sort repos per person for deterministic output
+for person in current_contributors:
+    if 'repos' in person and isinstance(person['repos'], list):
+        person['repos'] = sorted(set(person['repos']))
 
-np = []
-for i in newCoauthorList:
-    np.append({"name": i[0], "email": i[1], "status": "active", "comment": f"Co-author of commit {i[3]}","repos": [i[2]]})
-current_contributors.extend(np)
-
-sortedcurrent_contributors = sorted(current_contributors, key= lambda d: d['name'].split()[-1])
+# Final order by surname
+sortedcurrent_contributors = sorted(
+    current_contributors,
+    key=lambda d: (d.get('name', '').split()[-1], d.get('name', ''))
+)
 
 
 
@@ -348,37 +427,34 @@ sortedcurrent_contributors = sorted(current_contributors, key= lambda d: d['name
 # 9. Save the findings
 ##########################################
 
-# save yml to *NEW* file
-# how inefficient is list comprehension ?
-pilist = [dict(sorted(i.items(), key=custom_sort_function)) for i in sortedcurrent_contributors if i['status'] == "pi"]
-activelist = [dict(sorted(i.items(), key=custom_sort_function)) for i in sortedcurrent_contributors if i['status'] == "active"]
-retiredlist = [dict(sorted(i.items(), key=custom_sort_function)) for i in sortedcurrent_contributors if i['status'] == "retired"]
+# dump YAML with your custom sort
+pilist = [dict(sorted(i.items(), key=custom_sort_function)) for i in sortedcurrent_contributors if i.get('status') == "pi"]
+activelist = [dict(sorted(i.items(), key=custom_sort_function)) for i in sortedcurrent_contributors if i.get('status') == "active"]
+retiredlist = [dict(sorted(i.items(), key=custom_sort_function)) for i in sortedcurrent_contributors if i.get('status') == "retired"]
 
-# Hack copied from https://github.com/yaml/pyyaml/issues/127#issuecomment-525800484
 class MyDumper(yaml.SafeDumper):
-    # HACK: insert blank lines between top-level objects
-    # inspired by https://stackoverflow.com/a/44284819/3786245
     def write_line_break(self, data=None):
         super().write_line_break(data)
-
         if len(self.indents) == 1:
             super().write_line_break()
 
-# Write people_list.yml
-with open('../_data/people_list.yml', 'w') as outfile:
+os.chdir("..")
+with open('../_data/people_list.yml', 'w', encoding='utf-8') as outfile:
     outfile.write("# It is possible that people marked as 'retired' may have the repo key as an "
                   "empty array.\n# This is because people are marked as retired if the update "
                   "script could not find them in any repo.\n# Retired people only have repo "
                   "information if repo information about them was known when they were\n# active "
                   "(or manually added) by a maintainer.\n\n")
-    yaml.dump(sortedcurrent_contributors, outfile, Dumper=MyDumper, sort_keys = False, allow_unicode=True)
+    yaml.dump(sortedcurrent_contributors, outfile, Dumper=MyDumper, sort_keys=False, allow_unicode=True)
 
-# Produce summary
-summarystring = f"""This PR updates the contributors list based on the latest changes.
-New contributors : {len(newpersonlist)} | {newpersonlist}
-Revived contributors : {revcount} | {revpersonlist}
-Newly retired contributors : {retcount} | {retpersonlist}
-New co-authors : {len(newCoauthorList)} | {newCoauthorList}
-\nSummary Notes:\n\n"""+ summarystring
-with open(SUMMARY_FILE, 'w') as summaryfile:
+summarystring = (
+    f"This PR updates the contributors list based on the latest changes.\n"
+    f"New contributors : {len(newpersonlist)} | {newpersonlist}\n"
+    f"Revived contributors : {revcount} | {revpersonlist}\n"
+    f"Newly retired contributors : {retcount} | {retpersonlist}\n"
+    f"New co-authors : {len(newCoauthorList)} | {newCoauthorList}\n\n"
+    "Summary Notes:\n\n"
+) + summarystring
+
+with open(SUMMARY_FILE, 'w', encoding='utf-8') as summaryfile:
     summaryfile.write(summarystring)

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -4,6 +4,7 @@
 import json
 import os
 import subprocess
+import sys
 
 # Third-party
 import requests
@@ -65,15 +66,20 @@ def custom_sort_function(item):
 # 2. Read in intel from people_list.yml
 #######################################
 
-infile = PEOPLE_LIST_FILE
-with open(infile, "r") as ymlfile:
-    peopleList = yaml.safe_load(ymlfile)
+try:
+    with open(PEOPLE_LIST_FILE, "r", encoding="utf-8") as ymlfile:
+        peopleList = yaml.safe_load(ymlfile) or []
+except FileNotFoundError:
+    print(f"Error: Could not find {PEOPLE_LIST_FILE}")
+    sys.exit(1)
+except yaml.YAMLError as e:
+    print(f"Error parsing YAML file {PEOPLE_LIST_FILE}: {e}")
+    sys.exit(1)
 
-for i in peopleList:
-    if 'repos' not in i.keys():
-        i['repos'] = []
+for person in peopleList:
+    person.setdefault("repos", [])
 
-names = [i['github'] for i in peopleList if 'github' in i]
+names = [person["github"] for person in peopleList if "github" in person]
 
 
 

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -269,7 +269,12 @@ for repo in REPO_LIST:
     # 4.8 Go one step up, to prepare the scan in the next repository
     os.chdir("..")
 
-# 4.9 Enrich once across the consolidated people (skip API for now)
+
+
+##########################################
+# 5. Processing further
+##########################################
+
 unresolved = []
 newList = []
 newpersonlist = []
@@ -311,7 +316,7 @@ for rec in unresolved:
 
 
 ##########################################
-# 5. Sort as new, retired, active
+# 6. Sort as new, retired, active
 ##########################################
 
 newCoauthorList = []
@@ -360,7 +365,7 @@ sortedcurrent_contributors = sorted(current_contributors, key= lambda d: d['name
 
 
 ##########################################
-# 6. Save the findings
+# 7. Save the findings
 ##########################################
 
 # save yml to *NEW* file

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -288,14 +288,9 @@ people_sorted = sorted(current_contributors, key=lambda d: (d.get("name", "").sp
 ordered_people = [dict(sorted(p.items(), key=lambda kv: SORT_WEIGHT.get(kv[0], 999))) for p in people_sorted]
 
 # Write new content to PEOPLE_LIST_FILE
-class MyDumper(yaml.SafeDumper):
-    def write_line_break(self, data=None):
-        super().write_line_break(data)
-        if len(self.indents) == 1:
-            super().write_line_break()
 with open(PEOPLE_LIST_FILE, "w", encoding="utf-8") as f:
     f.write(YAML_HEADER)
-    yaml.dump(ordered_people, f, Dumper=MyDumper, sort_keys=False, allow_unicode=True)
+    yaml.dump(ordered_people, f, sort_keys=False, allow_unicode=True)
 
 # Create summary in SUMMARY_FILE
 new_names = [rec["name"] for rec in new_contributors]

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -55,8 +55,8 @@ SORT_WEIGHT = {"name": 0, "affiliation": 1, "email": 2, "github": 3, "website": 
 
 # Contributor lists and index structures
 current_contributors = []  # loaded from YAML
-email_owner = {}           # lowercased email → person dict
-name_owner = {}            # normalized name → person dict
+email_owner = {}           # lowercased email to person dict
+name_owner = {}            # normalized name to person dict
 
 # Aggregation state
 aggregate = {}
@@ -158,6 +158,10 @@ def process_log_into_aggregate(res: str, repo: str) -> None:
 def _repo_dir(repo_full: str) -> str:
     return os.path.join(REPOS_DIR, repo_full.split('/')[-1])
 
+def git_out(repo_dir: str, *args: str) -> str:
+    res = subprocess.run(["git", "-C", repo_dir, *args], check=True, capture_output=True, text=True, encoding="utf-8", errors="replace")
+    return res.stdout
+
 os.makedirs(REPOS_DIR, exist_ok=True)
 for repo in REPO_LIST:
     print(f"Processing {repo}...")
@@ -166,10 +170,8 @@ for repo in REPO_LIST:
         subprocess.run(["git", "clone", f"https://github.com/{repo}", repo_dir], check=True)
     else:
         subprocess.run(["git", "-C", repo_dir, "pull", "--ff-only"], check=True)
-    res = subprocess.run(
-        ["git", "-C", repo_dir, "log", "--use-mailmap", GIT_LOG_SINCE, GIT_LOG_FORMAT_1],
-        check=True, capture_output=True, text=True, encoding="utf-8", errors="replace")
-    process_log_into_aggregate(res.stdout, repo)
+    res_stdout = git_out(repo_dir, "log", "--use-mailmap", GIT_LOG_SINCE, GIT_LOG_FORMAT_1)
+    process_log_into_aggregate(res_stdout, repo)
 
 
 
@@ -177,17 +179,13 @@ for repo in REPO_LIST:
 # 6. Helpers to find (co)-author details
 ##########################################
 
-# Try to resolve a GitHub login by finding one authored commit for this email.
-def resolve_github_via_commit(email: str, repos: list[str]) -> str | None:
+def find_author_github_nick(email: str, repos: list[str]) -> str | None:
     if not email:
         return None
     for r in repos:
-        res = subprocess.run(
-            ["git", "-C", _repo_dir(r), "log", GIT_LOG_SINCE, f"--author={email}", "--format=%H", "-n", "1"],
-            check=True, capture_output=True, text=True, encoding="utf-8")
-        commit_hash = (res.stdout or "").strip()
+        commit_hash = git_out(_repo_dir(r), "log", GIT_LOG_SINCE, f"--author={email}", "--format=%H", "-n", "1").strip()
         if not commit_hash:
-            continue  # no direct authored commit in this repo (could be co-author only)
+            continue
         url = f"https://api.github.com/repos/{r}/commits/{commit_hash}"
         resp = requests.get(url, headers={"Authorization": f"Bearer {API_KEY}"})
         if resp.status_code != 200:
@@ -197,14 +195,11 @@ def resolve_github_via_commit(email: str, repos: list[str]) -> str | None:
             return author["login"]
     return None
 
-# Try to resolve a GitHub login by finding one co-authored commit for this email.
 def find_coauthor_commit(name: str, email: str, repos: list[str]) -> str:
     targets = {t for t in (name.lower(), email.lower()) if t}
     for r in repos:
-        res = subprocess.run(
-            ["git", "-C", _repo_dir(r), "log", GIT_LOG_SINCE, GIT_LOG_FORMAT_2],
-            check=True, capture_output=True, text=True, encoding="utf-8")
-        for line in res.stdout.splitlines():
+        out = git_out(_repo_dir(r), "log", GIT_LOG_SINCE, GIT_LOG_FORMAT_2)
+        for line in out.splitlines():
             low = line.lower()
             if not any(t in low for t in targets):
                 continue
@@ -223,7 +218,7 @@ for key, rec in aggregate.items():
     name  = rec["name"]
     email = rec["email"]
     repos = rec["repos"]
-    gh    = rec.get("known_github") or resolve_github_via_commit(email, repos)
+    gh    = rec.get("known_github") or find_author_github_nick(email, repos)
     user = lookup_user(gh, email, name)
 
     # Existing contributor

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -147,6 +147,7 @@ github_username = '__notfound__'
 summarystring = ""
 
 # 4.3 Run over repos
+aggregate = {}      # key -> {'name','email','is_author','known_github','repos': set()}
 for repo in REPO_LIST:
 
     print("\n")
@@ -252,138 +253,67 @@ for repo in REPO_LIST:
     # This replaces dnamelist with the consolidated one
     dnamelist = [[n, e, is_a, gh] for (n, e, is_a, gh) in by_person.values()]
 
-    # 3.8 Process dnamelist further - somehow...
-    count = 0
-    for i in dnamelist:
-        count = count+1
-        print(f"Item {count} of {len(dnamelist)}...")
-        print(i)
-        email = i[1]
-        is_author = bool(i[2])
-        known_github = i[3] if len(i) > 3 else None
-        process = subprocess.run(['git', 'log', f'--author={email}', '--format=%H', '-n 1'], capture_output=True)
-        hash = process.stdout.decode().strip()
-        github_commit_url = f"https://api.github.com/repos/{repo}/commits/{hash}"
-        #ask github API for username
-        r = requests.get(github_commit_url, headers={"Authorization":f"Bearer {API_KEY}"})
-        if r.status_code == 200:
-            j = json.loads(r.text)
-            github_username = '__notfound__'
-            if j['author'] == None:
-                # this commit was authored by someone and committed by someone else
-                # so github can't find a github user for the author, only for committed
-                # so we go through our list entire people list and see if we know the combination of
-                # name and email already
-                # or if the name exists in an aka
-                # or if the email exists in aka_email
-                flag = False
-                for person in current_contributors:
-                    if 'email' in person.keys() and 'name' in person.keys():
-                        if i[0] == person['name'] and i[1] == person['email']:
-                            # we know the person, check if we know the github ID
-                            if 'github' in person.keys() and person['github'] != '':
-                                # we know the person and the github, just mark person as active
-                                github_username = person['github']
-                                flag = True
-                                break
-                        elif "aka" in person:
-                            # the person has an alias
-                            if i[0] in person["aka"]:
-                                if 'github' in person.keys() and person['github'] != '':
-                                    # we know the person and the github, just mark person as active
-                                    github_username = person['github']
-                                    flag = True
-                                    break
-                        elif "aka_email" in person:
-                            # the person has an alias email
-                            if i[1] in person["aka_email"]:
-                                if 'github' in person.keys() and person['github'] != '':
-                                    # we know the person and the github, just mark person as active
-                                    github_username = person['github']
-                                    flag = True
-                                    break
-                if not flag:
-                    summarystring += f"- Github username not found for {i[0]} with email {i[1]}. Excluding from people_list.yml\n"
-                    continue
-            if github_username == '__notfound__':
-                github_username = j['author']['login']
-        elif github_commit_url == f"https://api.github.com/repos/{repo}/commits/":
-            # this is a case of a co-author
-            flag = False
-            for person in current_contributors:
-                if 'email' in person.keys() and 'name' in person.keys():
-                    if i[0] == person['name'] and i[1] == person['email']:
-                            flag = True
-                            break
-                    elif "aka" in person:
-                        # the person has an alias
-                        if i[0] in person["aka"]:
-                            if 'github' in person.keys() and person['github'] != '':
-                                # we know the person and the github, just mark person as active
-                                github_username = person['github']
-                                flag = True
-                                break
-                    elif "aka_email" in person:
-                        # the person has an alias email
-                        if i[1] in person["aka_email"]:
-                            if 'github' in person.keys() and person['github'] != '':
-                                # we know the person and the github, just mark person as active
-                                github_username = person['github']
-                                flag = True
-                                break
-                    elif i[0] == person['name'] or i[1] == person['email']:
-                        github_username = person['github']
-                        flag = True
-                        break
-            if not flag:
-                # a co-author we don't know about at all - find a commit hash that mentions them
-                res = subprocess.run(["git", "log", GIT_LOG_SINCE, GIT_LOG_FORMAT_2],capture_output=True, text=True)
-                if res.returncode != 0:
-                    print("ERROR: git log for co-author failed:", res.stderr.strip())
-                    exit(1)
-                commit_hash = None
-                target_lower = {i[0].lower(), i[1].lower()}
-                for line in res.stdout.splitlines():
-                    lower = line.lower()
-                    if any(t in lower for t in target_lower):
-                        parts = line.split()
-                        if parts:
-                            commit_hash = parts[0]
-                            break
-                if commit_hash == None:
-                    print(f"ERROR: Could not find a commit hash for co-author {i[0]} <{i[1]}> in {repo}")
-                    exit(1)
-                newCoauthorList.append([i[0], i[1], repo, commit_hash])
+    # 4.8 Aggregate across repos (no API calls here)
+    for name, email, is_author, known_github in dnamelist:
+        key = _person_key(name, email)
+        rec = aggregate.get(key)
+        if rec is None:
+            aggregate[key] = {
+                "name": name,
+                "email": email,
+                "is_author": bool(is_author),
+                "known_github": known_github,
+                "repos": set([repo]),
+            }
         else:
-            # this will never happen, except if the API lies to you
-            # or blocks access
-            print(r.status_code)
-            print(r)
-            print(r.text)
-            print(email)
-            print(github_commit_url)
-            github_username = "__notfound__"
-            flag = False
-
-        assert github_username != "__notfound__"
-        if github_username not in current_github_usernames and github_username not in github_newusers and github_username != "__notfound__":
-            print("A new contributor!")
-            newpersonlist.append(i[0])
-            print(f"{i[0]}\t{i[1]}\t{github_username}")
-            github_newusers.append(github_username)
-            newList.append([i[0], i[1], github_username, [repo]])
-        elif github_username in current_github_usernames:
-            user = [item for item in current_contributors if 'github' in item and item['github'] == github_username][0]
-            if repo not in user['repos']:
-                user['repos'].append(repo)
-        else:
-            # github_username in github_newusers
-            user = [item for item in newList if item[2] == github_username][0]
-            if repo not in user[3]:
-                user[3].append(repo)
-        if github_username not in github_userlist:
-            github_userlist.append(github_username)
+            # merge flags and better data
+            if not rec["is_author"] and bool(is_author):
+                rec["is_author"] = True
+            rec["repos"].add(repo)
+            if known_github and not rec["known_github"]:
+                rec["known_github"] = known_github
+            # prefer non-noreply email (and the name that came with it)
+            if "users.noreply.github.com" in rec["email"] and "users.noreply.github.com" not in email:
+                rec["name"], rec["email"] = name, email
+    
+    # 4.9 Go one step up, to prepare the scan in the next repository
     os.chdir("..")
+
+# 4.10 Enrich once across the consolidated people (skip API for now)
+unresolved = []
+
+for key, rec in aggregate.items():
+    name = rec["name"]
+    email = rec["email"]
+    repos = sorted(rec["repos"])
+    gh = rec["known_github"]
+
+    if gh:
+        # Known GitHub from YAML
+        if gh in current_github_usernames:
+            # existing contributor: just append repos
+            user = next((it for it in current_contributors if it.get("github") == gh), None)
+            if user is not None:
+                for r in repos:
+                    if r not in user.setdefault("repos", []):
+                        user["repos"].append(r)
+        else:
+            # new contributor (known gh from aliases)
+            newpersonlist.append(name)
+            github_newusers.append(gh)
+            newList.append([name, email, gh, repos])
+        if gh not in github_userlist:
+            github_userlist.append(gh)
+    else:
+        # No GitHub yet — leave for a later step (or future API pass)
+        unresolved.append(rec)
+
+# Optional: note unresolved folks so they don't silently vanish
+for rec in unresolved:
+    summarystring += (
+        f"- Github username not found for {rec['name']} <{rec['email']}>; "
+        f"repos={sorted(rec['repos'])}. Skipping for now.\n"
+    )
 
 
 

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -96,6 +96,8 @@ active_contributors = []            # references to active current_contributors 
 new_contributors = []               # data of new (co)authors in unified schema: {"name","email","repos","github|None","commit_hash|None"}
 _seen_current = set()               # track object identity for computation of retired contributors
 retired_contributors = []           # references to retired current_contributors entries
+_prev_status = {}                   # Status of people before we match them against aggregate and thus update their status
+newly_retired_names = []            # The list of the names of people who retired recently
 sorted_current_contributors = []    # the current contributors - new active, retired, PI sorted by name
 ordered_people = []                 # final list of sorted current contributors, with each field sorted by our custom design in SORT_WEIGHT
 
@@ -359,6 +361,7 @@ retired_contributors = [p for p in current_contributors if id(p) not in _seen_cu
 ##########################################
 
 _prev_status = {id(p): p.get("status") for p in current_contributors}
+newly_retired_names = [p.get("name") for p in retired_contributors if _prev_status.get(id(p)) == "active"]
 
 for rec in new_contributors:
     newp = {"name": rec["name"], "email": rec["email"], "repos": sorted(set(rec["repos"])), "status": "active"}
@@ -388,6 +391,7 @@ ordered_people = [dict(sorted(person.items(), key=custom_sort_function)) for per
 
 
 
+
 ##########################################
 # 10. Save the findings to YML file
 ##########################################
@@ -413,12 +417,9 @@ with open(PEOPLE_LIST_FILE, "w", encoding="utf-8") as outfile:
 # 11. Write summary text
 ##########################################
 
-new_names = [rec["name"] for rec in new_contributors]
-newly_retired_names = [p.get("name") for p in retired_contributors if _prev_status.get(id(p)) == "active"]
-
 summarystring = (
     "This PR updates the contributors list based on the latest changes.\n"
-    f"New contributors : {len(new_names)} | {new_names}\n"
+    f"New contributors : {len(new_contributors)} | {[rec["name"] for rec in new_contributors]}\n"
     f"Newly retired contributors : {len(newly_retired_names)} | {newly_retired_names}\n\n"
     "Summary Notes:\n\n"
 ) + summarystring

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -92,10 +92,12 @@ aggregate = {}
 summarystring = ""
 
 # Once we aggregated the current contributors, we fill them into the following buckets
-active_contributors = []   # references to active current_contributors entries
-new_contributors = []      # data of new (co)authors in unified schema: {"name","email","repos","github|None","commit_hash|None"}
-_seen_current = set()      # track object identity for computation of retired contributors
-retired_contributors = []  # references to retired current_contributors entries
+active_contributors = []            # references to active current_contributors entries
+new_contributors = []               # data of new (co)authors in unified schema: {"name","email","repos","github|None","commit_hash|None"}
+_seen_current = set()               # track object identity for computation of retired contributors
+retired_contributors = []           # references to retired current_contributors entries
+sorted_current_contributors = []    # the current contributors - new active, retired, PI sorted by name
+ordered_people = []                 # final list of sorted current contributors, with each field sorted by our custom design in SORT_WEIGHT
 
 
 
@@ -353,109 +355,42 @@ retired_contributors = [p for p in current_contributors if id(p) not in _seen_cu
 
 
 ##########################################
-# 9. Update YAML structure (add new, set statuses)
+# 9. Update YAML structure
 ##########################################
 
-# Snapshot previous statuses to compute revive/retire counts
 _prev_status = {id(p): p.get("status") for p in current_contributors}
 
-# Add new contributors to YAML
-# - Authors: include email unless it’s a GH noreply
-# - Coauthors: no github, add a comment with the representative hash
-added_names = []
-added_coauthors = 0
-
 for rec in new_contributors:
-    name   = rec["name"]
-    email  = rec["email"]
-    repos  = sorted(set(rec["repos"]))  # deterministic output
-    gh     = rec["github"]
-    chash  = rec["commit_hash"]
-
-    if gh:
-        # New author
-        if "users.noreply.github.com" in (email or ""):
-            newp = {"name": name, "github": gh, "status": "active", "repos": repos}
-            summarystring += f"- Email not found for {name} ({gh}).\n"
-        else:
-            newp = {"name": name, "email": email, "github": gh, "status": "active", "repos": repos}
-        current_contributors.append(newp)
-        added_names.append(name)
+    newp = {"name": rec["name"], "email": rec["email"], "repos": sorted(set(rec["repos"])), "status": "active"}
+    if rec["github"]:
+        newp["github"] = rec["github"]
     else:
-        # New coauthor
-        newp = {
-            "name": name,
-            "email": email,
-            "status": "active",
-            "comment": f"Co-author of commit {chash}",
-            "repos": repos,
-        }
-        current_contributors.append(newp)
-        added_coauthors += 1
-        added_names.append(name)
+        newp["comment"] = f"Co-author of commit {rec['commit_hash']}"
+    current_contributors.append(newp)
 
-# Build a quick lookup for "active this run" using a stable key (github or email)
-def _person_key_for_status(p: dict) -> str:
-    gh = p.get("github")
-    if gh:
-        return f"gh:{gh}"
-    em = p.get("email")
-    return f"email:{(em or '').lower()}"
+for p in active_contributors:
+    p["status"] = "active"
 
-_active_keys = {_person_key_for_status(p) for p in active_contributors}
+for p in retired_contributors:
+    if p.get("status") != "pi":
+        p["status"] = "retired"
 
-# Update statuses for existing people (PIs untouched, coauthors-without-github untouched)
-revcount = 0
-retcount = 0
-revpersonlist = []
-retpersonlist = []
+for p in current_contributors:
+    p["repos"] = sorted(set(p["repos"]))
 
-for person in current_contributors:
-    if person.get("status") == "pi":
-        continue  # never touch PIs
+sorted_current_contributors = sorted(current_contributors, key=lambda d: (d.get("name", "").split()[-1], d.get("name", "")))
 
-    # Co-authors (no github) keep their status (treat as active-ish), as in the prior logic
-    if not person.get("github"):
-        continue
-
-    key = _person_key_for_status(person)
-    was = person.get("status")
-
-    if key in _active_keys:
-        # Active this period
-        if was == "retired":
-            revcount += 1
-            revpersonlist.append(person.get("name"))
-        person["status"] = "active"
-    else:
-        # Not seen this period → retired
-        if was == "active":
-            retcount += 1
-            retpersonlist.append(person.get("name"))
-        person["status"] = "retired"
-
-# Normalize & sort repos per person for deterministic output
-for person in current_contributors:
-    if isinstance(person.get("repos"), list):
-        person["repos"] = sorted(set(person["repos"]))
-
-# Final order by surname
-sortedcurrent_contributors = sorted(
-    current_contributors,
-    key=lambda d: (d.get("name", "").split()[-1], d.get("name", ""))
-)
-
-
-
-##########################################
-# 10. Save the findings
-##########################################
-
-# custom sort function
 def custom_sort_function(item):
-    name, _ = item
-    sortweight = SORT_WEIGHT
-    return sortweight[name]
+    key, _ = item
+    return SORT_WEIGHT.get(key, 999)
+
+ordered_people = [dict(sorted(person.items(), key=custom_sort_function)) for person in sorted_current_contributors]
+
+
+
+##########################################
+# 10. Save the findings to YML file
+##########################################
 
 class MyDumper(yaml.SafeDumper):
     def write_line_break(self, data=None):
@@ -463,27 +398,30 @@ class MyDumper(yaml.SafeDumper):
         if len(self.indents) == 1:
             super().write_line_break()
 
-with open(PEOPLE_LIST_FILE, 'w', encoding='utf-8') as outfile:
-    outfile.write("# It is possible that people marked as 'retired' may have the repo key as an "
-                  "empty array.\n# This is because people are marked as retired if the update "
-                  "script could not find them in any repo.\n# Retired people only have repo "
-                  "information if repo information about them was known when they were\n# active "
-                  "(or manually added) by a maintainer.\n\n")
-    yaml.dump(sortedcurrent_contributors, outfile, Dumper=MyDumper, sort_keys=False, allow_unicode=True)
+with open(PEOPLE_LIST_FILE, "w", encoding="utf-8") as outfile:
+    outfile.write(
+        "# It is possible that people marked as 'retired' may have the repo key as an empty array.\n"
+        "# This is because people are marked as retired if the update script could not find them in any repo.\n"
+        "# Retired people only have repo information if repo information about them was known when they were\n"
+        "# active (or manually added) by a maintainer.\n\n"
+    )
+    yaml.dump(ordered_people, outfile, Dumper=MyDumper, sort_keys=False, allow_unicode=True)
 
-# Build the summary text
-newpersonlist = added_names
-newCoauthorList = [c for c in new_contributors if not c["github"]]
+
+
+##########################################
+# 11. Write summary text
+##########################################
+
+new_names = [rec["name"] for rec in new_contributors]
+newly_retired_names = [p.get("name") for p in retired_contributors if _prev_status.get(id(p)) == "active"]
 
 summarystring = (
     "This PR updates the contributors list based on the latest changes.\n"
-    f"New contributors : {len(newpersonlist)} | {newpersonlist}\n"
-    f"Revived contributors : {revcount} | {revpersonlist}\n"
-    f"Newly retired contributors : {retcount} | {retpersonlist}\n"
-    f"New co-authors : {len(newCoauthorList)} | "
-    f"{[(c['name'], c['email'], c['commit_hash']) for c in newCoauthorList]}\n\n"
+    f"New contributors : {len(new_names)} | {new_names}\n"
+    f"Newly retired contributors : {len(newly_retired_names)} | {newly_retired_names}\n\n"
     "Summary Notes:\n\n"
 ) + summarystring
 
-with open(SUMMARY_FILE, 'w', encoding='utf-8') as summaryfile:
+with open(SUMMARY_FILE, "w", encoding="utf-8") as summaryfile:
     summaryfile.write(summarystring)

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -13,7 +13,6 @@ import requests
 import yaml
 
 
-
 ##########################################
 # 1. Constants (static configuration)
 ##########################################
@@ -54,7 +53,6 @@ YAML_HEADER = (
     "# active (or manually added) by a maintainer.\n\n")
 
 
-
 ##########################################
 # 2. Globals (runtime state; mutated)
 ##########################################
@@ -73,7 +71,6 @@ new_contributors = []
 _seen_current = set()
 
 
-
 ##########################################
 # 3. Read information from people_list.yml
 ##########################################
@@ -90,7 +87,6 @@ except yaml.YAMLError as e:
 
 for person in current_contributors:
     person.setdefault("repos", [])
-
 
 
 ##########################################
@@ -114,7 +110,6 @@ for p in current_contributors:
 
 def lookup_user(gh, email, name):
     return ((gh and name_owner.get(_norm_name(gh))) or (email and email_owner.get(email.casefold())) or name_owner.get(_norm_name(name)))
-
 
 
 ##########################################
@@ -180,7 +175,6 @@ for repo in REPO_LIST:
     process_log_into_aggregate(res_stdout, repo)
 
 
-
 ##########################################
 # 6. Helpers to find (co)-author details
 ##########################################
@@ -213,7 +207,6 @@ def find_coauthor_commit(name: str, email: str, repos: list[str]) -> str:
             if m:
                 return m.group(0)
     return "(no hash found)"
-
 
 
 ##########################################
@@ -250,7 +243,6 @@ for key, rec in aggregate.items():
         else:   # New "coauthor" — resolve a representative commit immediately
             commit_hash = find_coauthor_commit(name, email, repos)
             new_contributors.append({"name": name, "email": email, "repos": repos, "github": None, "commit_hash": commit_hash})
-
 
 
 ##########################################

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -257,21 +257,12 @@ for key, rec in aggregate.items():
 # 8. Apply updates and dump output
 ##########################################
 
-##########################################
-# 8. Apply updates and dump output
-##########################################
-
 # Snapshot previous statuses for "newly retired" reporting
 _prev_status = {id(p): p.get("status") for p in current_contributors}
 
 # Add new contributors
 for rec in new_contributors:
-    newp = {
-        "name": rec["name"],
-        "email": rec["email"],
-        "repos": sorted(set(rec["repos"])),
-        "status": "active",
-    }
+    newp = {"name": rec["name"], "email": rec["email"], "repos": sorted(set(rec["repos"])), "status": "active"}
     if rec["github"]:
         newp["github"] = rec["github"]
     else:
@@ -287,9 +278,6 @@ for p in current_contributors:
     else:
         p["status"] = "retired"
 
-# Compute newly retired contributors for the summary
-newly_retired_names = [p.get("name") for p in current_contributors if p.get("status") == "retired" and _prev_status.get(id(p)) == "active"]
-
 # Normalize repos list deterministically
 for p in current_contributors:
     p["repos"] = sorted(set(p["repos"]))
@@ -302,10 +290,10 @@ with open(PEOPLE_LIST_FILE, "w", encoding="utf-8") as f:
     yaml.dump(ordered_people, f, sort_keys=False, allow_unicode=True)
 
 # Create summary in SUMMARY_FILE
-new_names = [rec["name"] for rec in new_contributors]
+newly_retired_names = [p.get("name") for p in current_contributors if p.get("status") == "retired" and _prev_status.get(id(p)) == "active"]
 summary = (
     "This PR updates the contributors list based on the latest changes.\n"
-    f"New contributors : {len(new_names)} | {new_names}\n"
+    f"New contributors : {len(new_contributors)} | {[rec["name"] for rec in new_contributors]}\n"
     f"Newly retired contributors : {len(newly_retired_names)} | {newly_retired_names}\n\n"
     "Summary Notes:\n\n"
 ) + summarystring

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -18,9 +18,9 @@ import yaml
 # 1. Constants (static configuration)
 ##########################################
 
-# Derive absolute paths once so chdir() doesn’t bite us later.
+# Paths
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-PROJECT_ROOT = os.path.abspath(os.path.join(BASE_DIR, ".."))
+PROJECT_ROOT = os.path.dirname(BASE_DIR)
 REPOS_DIR = os.path.join(PROJECT_ROOT, "repos")
 PEOPLE_LIST_FILE = os.path.join(PROJECT_ROOT, "_data", "people_list.yml")
 SUMMARY_FILE = os.path.join(PROJECT_ROOT, "summary.txt")
@@ -34,42 +34,18 @@ GIT_LOG_FORMAT_1 = "--format=%aN <%aE>%n%(trailers:unfold,key=Co-authored-by)"
 GIT_LOG_FORMAT_2 = "--format=%H %(trailers:only,unfold,separator=|,key=Co-authored-by) %s"
 
 # Repositories to scan (tuple to emphasize immutability)
-REPO_LIST = (
-    "Nemocas/AbstractAlgebra.jl",
-    "algebraic-solving/AlgebraicSolving.jl",
-    "oscar-system/GAP.jl",
-    "thofma/Hecke.jl",
-    "Nemocas/Nemo.jl",
-    "oscar-system/Oscar.jl",
-    "oscar-system/Polymake.jl",
-    "oscar-system/Singular.jl",
-)
+REPO_LIST = ("Nemocas/AbstractAlgebra.jl", "algebraic-solving/AlgebraicSolving.jl", "oscar-system/GAP.jl", "thofma/Hecke.jl",
+             "Nemocas/Nemo.jl", "oscar-system/Oscar.jl", "oscar-system/Polymake.jl", "oscar-system/Singular.jl")
 
 # Bots we ignore
-BOT_TOKENS = (
-    "github-actions[bot]",
-    "dependabot[bot]",
-    "renovate[bot]",
-    "changelog[bot]",
-)
+BOT_TOKENS = ("github-actions[bot]", "dependabot[bot]", "renovate[bot]", "changelog[bot]")
 
 # Regexes
 HASH_RE = re.compile(r"\b[0-9a-f]{40}\b", re.I)
 
 # Display/sort preferences
-SORT_WEIGHT = {
-    "name": 0,
-    "affiliation": 1,
-    "email": 2,
-    "github": 3,
-    "website": 4,
-    "paid_by_dfg": 5,
-    "status": 6,
-    "comment": 7,
-    "aka": 8,
-    "aka_email": 9,
-    "repos": 10,
-}
+SORT_WEIGHT = {"name": 0, "affiliation": 1, "email": 2, "github": 3, "website": 4, "paid_by_dfg": 5,
+               "status": 6, "comment": 7, "aka": 8, "aka_email": 9, "repos": 10}
 
 
 

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -69,7 +69,7 @@ aggregate = {}
 summarystring = ""
 
 # Classification buckets
-active_contributors, new_contributors, retired_contributors = [], [], []
+new_contributors = []
 _seen_current = set()
 
 
@@ -242,7 +242,6 @@ for key, rec in aggregate.items():
         uid = id(user)
         if uid not in _seen_current:
             _seen_current.add(uid)
-            active_contributors.append(user)
 
     # Brand-new person; authors & coauthors treated uniformly
     else:
@@ -252,42 +251,52 @@ for key, rec in aggregate.items():
             commit_hash = find_coauthor_commit(name, email, repos)
             new_contributors.append({"name": name, "email": email, "repos": repos, "github": None, "commit_hash": commit_hash})
 
-# Retired = in current_contributors but not seen in this run
-retired_contributors = [p for p in current_contributors if id(p) not in _seen_current]
-
 
 
 ##########################################
 # 8. Apply updates and dump output
 ##########################################
 
-# Find the newly retired contributors
-_prev_status = {id(p): p.get("status") for p in current_contributors}
-newly_retired_names = [p.get("name") for p in retired_contributors if _prev_status.get(id(p)) == "active"]
+##########################################
+# 8. Apply updates and dump output
+##########################################
 
-# Apply updates
+# Snapshot previous statuses for "newly retired" reporting
+_prev_status = {id(p): p.get("status") for p in current_contributors}
+
+# Add new contributors
 for rec in new_contributors:
-    newp = {"name": rec["name"], "email": rec["email"], "repos": sorted(set(rec["repos"])), "status": "active"}
+    newp = {
+        "name": rec["name"],
+        "email": rec["email"],
+        "repos": sorted(set(rec["repos"])),
+        "status": "active",
+    }
     if rec["github"]:
         newp["github"] = rec["github"]
     else:
         newp["comment"] = f"Co-author of commit {rec['commit_hash']}"
     current_contributors.append(newp)
-for p in active_contributors:
-    p["status"] = "active"
-for p in retired_contributors:
-    if p.get("status") != "pi":
+
+# Set statuses for everyone (PIs untouched)
+for p in current_contributors:
+    if p.get("status") == "pi":
+        continue
+    if id(p) in _seen_current:
+        p["status"] = "active"
+    else:
         p["status"] = "retired"
+
+# Compute newly retired contributors for the summary
+newly_retired_names = [p.get("name") for p in current_contributors if p.get("status") == "retired" and _prev_status.get(id(p)) == "active"]
 
 # Normalize repos list deterministically
 for p in current_contributors:
     p["repos"] = sorted(set(p["repos"]))
 
-# Final order by surname, then tidy field order
+# Write new content to PEOPLE_LIST_FILE
 people_sorted = sorted(current_contributors, key=lambda d: (d.get("name", "").split()[-1], d.get("name", "")))
 ordered_people = [dict(sorted(p.items(), key=lambda kv: SORT_WEIGHT.get(kv[0], 999))) for p in people_sorted]
-
-# Write new content to PEOPLE_LIST_FILE
 with open(PEOPLE_LIST_FILE, "w", encoding="utf-8") as f:
     f.write(YAML_HEADER)
     yaml.dump(ordered_people, f, sort_keys=False, allow_unicode=True)

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -146,15 +146,12 @@ def process_log_into_aggregate(res: str, repo: str) -> None:
         known_github = owner.get("github") if owner else None
         key = ("gh", known_github.casefold()) if known_github else ("email", ((owner and owner.get("email")) or email).casefold())
 
-        rec = aggregate.get(key)
-        if rec is None:
-            aggregate[key] = {"name": name, "email": email, "known_github": known_github, "repos": {repo}}
-        else:
-            rec["repos"].add(repo)
-            if known_github and not rec["known_github"]:
-                rec["known_github"] = known_github
-            if "users.noreply.github.com" in rec["email"] and "users.noreply.github.com" not in email:
-                rec["name"], rec["email"] = name, email
+        rec = aggregate.setdefault(key, {"name": name, "email": email, "known_github": known_github, "repos": set()})
+        rec["repos"].add(repo)
+        if known_github and not rec["known_github"]:
+            rec["known_github"] = known_github
+        if "users.noreply.github.com" in rec["email"] and "users.noreply.github.com" not in email:
+            rec["name"], rec["email"] = name, email
 
 def _repo_dir(repo_full: str) -> str:
     return os.path.join(REPOS_DIR, repo_full.split('/')[-1])

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -136,7 +136,7 @@ def lookup_user(gh, email, name):
 
 
 ##########################################
-# 5. Helper: Process git log
+# 5. Find (co)authors of all repos
 ##########################################
 
 def process_log_into_aggregate(res: str, repo: str) -> None:
@@ -179,12 +179,6 @@ def process_log_into_aggregate(res: str, repo: str) -> None:
             if "users.noreply.github.com" in rec["email"] and "users.noreply.github.com" not in email:
                 rec["name"], rec["email"] = name, email
 
-
-
-##########################################
-# 6. Find (co)authors of all repos
-##########################################
-
 def _repo_dir(repo_full: str) -> str:
     return os.path.join(REPOS_DIR, repo_full.split('/')[-1])
 
@@ -204,7 +198,7 @@ for repo in REPO_LIST:
 
 
 ##########################################
-# 7. Helpers to find (co)-author details
+# 6. Helpers to find (co)-author details
 ##########################################
 
 # Try to resolve a GitHub login by finding one authored commit for this email.
@@ -246,7 +240,7 @@ def find_coauthor_commit(name: str, email: str, repos: list[str]) -> str:
 
 
 ##########################################
-# 8. Post-aggregation enrichment & updates
+# 7. Post-aggregation enrichment & updates
 ##########################################
 
 for key, rec in aggregate.items():
@@ -287,7 +281,7 @@ retired_contributors = [p for p in current_contributors if id(p) not in _seen_cu
 
 
 ##########################################
-# 9. Apply updates and dump output
+# 8. Apply updates and dump output
 ##########################################
 
 # Find the newly retired contributors

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -1,3 +1,7 @@
+#######################################
+# 1. Imports
+#######################################
+
 #!/usr/bin/env python3
 import os
 import json
@@ -5,22 +9,23 @@ import yaml
 import requests
 import subprocess
 
-def custom_sort_function(item):
-    name, _ = item
-    sortweight = {"name": 0, "affiliation": 1, "email": 2, "github": 3, "website": 4,
-                  "paid_by_dfg": 5,"status": 6, "comment": 7, "aka": 8, "aka_email": 9,
-                  "repos": 10}
-    return sortweight[name]
 
-# Hack copied from https://github.com/yaml/pyyaml/issues/127#issuecomment-525800484
-class MyDumper(yaml.SafeDumper):
-    # HACK: insert blank lines between top-level objects
-    # inspired by https://stackoverflow.com/a/44284819/3786245
-    def write_line_break(self, data=None):
-        super().write_line_break(data)
 
-        if len(self.indents) == 1:
-            super().write_line_break()
+#######################################
+# 2. Constants
+#######################################
+
+repoList = ["thofma/Hecke.jl", "oscar-system/Oscar.jl", "Nemocas/Nemo.jl",
+            "Nemocas/AbstractAlgebra.jl", "oscar-system/GAP.jl", "oscar-system/Polymake.jl",
+            "oscar-system/Singular.jl", "algebraic-solving/AlgebraicSolving.jl"]
+
+API_KEY = (os.getenv("API_KEY") or os.getenv("GITHUB_TOKEN") or "").strip()
+
+
+
+#######################################
+# 3. Read in intel from people_list.yml
+#######################################
 
 infile = "../_data/people_list.yml"
 with open(infile, "r") as ymlfile:
@@ -31,9 +36,25 @@ for i in peopleList:
         i['repos'] = []
 
 names = [i['github'] for i in peopleList if 'github' in i]
-repoList = ["thofma/Hecke.jl", "oscar-system/Oscar.jl", "Nemocas/Nemo.jl",
-            "Nemocas/AbstractAlgebra.jl", "oscar-system/GAP.jl", "oscar-system/Polymake.jl",
-            "oscar-system/Singular.jl", "algebraic-solving/AlgebraicSolving.jl"]
+
+
+
+#######################################
+# 4. Custom sort function
+#######################################
+
+def custom_sort_function(item):
+    name, _ = item
+    sortweight = {"name": 0, "affiliation": 1, "email": 2, "github": 3, "website": 4,
+                  "paid_by_dfg": 5,"status": 6, "comment": 7, "aka": 8, "aka_email": 9,
+                  "repos": 10}
+    return sortweight[name]
+
+
+
+#######################################
+# 5. Collect (co)authors for each repo
+#######################################
 
 newList = []
 newCoauthorList = []
@@ -42,7 +63,6 @@ newpersonlist = []
 github_newusers = []
 github_userlist = []
 github_username = '__notfound__'
-API_KEY = (os.getenv("API_KEY") or os.getenv("GITHUB_TOKEN") or "").strip()
 summarystring = ""
 # grab currently active devs
 if not os.path.isdir("repos"):
@@ -225,6 +245,12 @@ for repo in repoList:
             github_userlist.append(github_username)
     os.chdir("..")
 
+
+
+#######################################
+# 6. Sort as new, retired, active
+#######################################
+
 # mark active / retired
 # if PI, don't touch them
 os.chdir("..")
@@ -266,11 +292,29 @@ peopleList.extend(np)
 
 sortedPeopleList = sorted(peopleList, key= lambda d: d['name'].split()[-1])
 
+
+
+#######################################
+# 7. Save the findings
+#######################################
+
 # save yml to *NEW* file
 # how inefficient is list comprehension ?
 pilist = [dict(sorted(i.items(), key=custom_sort_function)) for i in sortedPeopleList if i['status'] == "pi"]
 activelist = [dict(sorted(i.items(), key=custom_sort_function)) for i in sortedPeopleList if i['status'] == "active"]
 retiredlist = [dict(sorted(i.items(), key=custom_sort_function)) for i in sortedPeopleList if i['status'] == "retired"]
+
+# Hack copied from https://github.com/yaml/pyyaml/issues/127#issuecomment-525800484
+class MyDumper(yaml.SafeDumper):
+    # HACK: insert blank lines between top-level objects
+    # inspired by https://stackoverflow.com/a/44284819/3786245
+    def write_line_break(self, data=None):
+        super().write_line_break(data)
+
+        if len(self.indents) == 1:
+            super().write_line_break()
+
+# Write people_list.yml
 with open('../_data/people_list.yml', 'w') as outfile:
     outfile.write("# It is possible that people marked as 'retired' may have the repo key as an "
                   "empty array.\n# This is because people are marked as retired if the update "
@@ -279,12 +323,12 @@ with open('../_data/people_list.yml', 'w') as outfile:
                   "(or manually added) by a maintainer.\n\n")
     yaml.dump(sortedPeopleList, outfile, Dumper=MyDumper, sort_keys = False, allow_unicode=True)
 
+# Produce summary
 summarystring = f"""This PR updates the contributors list based on the latest changes.
 New contributors : {len(newpersonlist)} | {newpersonlist}
 Revived contributors : {revcount} | {revpersonlist}
 Newly retired contributors : {retcount} | {retpersonlist}
 New co-authors : {len(newCoauthorList)} | {newCoauthorList}
 \nSummary Notes:\n\n"""+ summarystring
-
 with open("../summary.txt", 'w') as summaryfile:
     summaryfile.write(summarystring)

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -324,7 +324,11 @@ for key, rec in aggregate.items():
     email = rec["email"]
     repos = rec["repos"]
     gh    = rec.get("known_github") or resolve_github_via_commit(email, repos)
-    user = (name_owner.get(gh) or (email and email_owner.get(email.lower())) or name_owner.get(_norm_name(name)))
+    user = (
+        (gh and name_owner.get(_norm_name(gh)))
+        or (email and email_owner.get(email.lower()))
+        or name_owner.get(_norm_name(name))
+    )
 
     # Existing contributor
     if user:

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -140,76 +140,45 @@ def lookup_user(gh, email, name):
 ##########################################
 
 def process_log_into_aggregate(res: str, repo: str) -> None:
-
-    global summarystring, aggregate, email_owner, name_owner
-
+    global summarystring, aggregate  #, email_owner, name_owner
     for raw in res.splitlines():
-
-        # Prepare the line and skip if empty
         line = raw.strip()
-        if not line:
-            continue
+        if not line: continue
 
-        # Identify co-authors
         is_author = True
         if line.lower().startswith("co-authored-by:"):
             line = line.split(":", 1)[1].strip()
             is_author = False
-        
-        # Skip bots and non-address lines
-        lower_line = line.lower()
-        if any(b in lower_line for b in BOT_TOKENS):
+
+        low = line.lower()
+        if any(b in low for b in BOT_TOKENS):
             continue
-        if "[bot]" in lower_line:
+        if "[bot]" in low:
             summarystring += f"- Skipping suspected bot line in {repo}: {line!r}\n"
             continue
         if "<" not in line or ">" not in line:
             summarystring += f"- Skipping non-address line in {repo}: {line!r}\n"
             continue
 
-        # Parse "Name <email>"
         name, email = parseaddr(line)
-        name = " ".join(unicodedata.normalize("NFKC", name).split())
+        name  = " ".join(unicodedata.normalize("NFKC", name).split())
         email = unicodedata.normalize("NFKC", email).strip()
-
-        # Validate
-        if not email and not name:
-            summarystring += f"- Missing name and email in {repo}; line={line!r}; skipping\n"
-            continue
-        if not email:
-            summarystring += f"- Missing email for '{name}' in {repo}; skipping\n"
-            continue
-        if not name:
-            summarystring += f"- Missing name for '{email}' in {repo}; skipping\n"
+        if not email or not name:
+            summarystring += f"- Missing {'email' if not email else 'name'} for {name or email} in {repo}; skipping\n"
             continue
 
-        # Alias resolution from PEOPLE_LIST_FILE (aka/aka_email)
-        owner = email_owner.get(email.lower()) or name_owner.get(_norm_name(name))
+        owner = email_owner.get(email.casefold()) or name_owner.get(_norm_name(name))
         known_github = owner.get("github") if owner else None
+        key = ("gh", known_github.lower()) if known_github else ("email", ((owner and owner.get("email")) or email).casefold())
 
-        # Person key: prefer github if known; else canonical email via owner; else raw email
-        key = ("gh", known_github.lower()) if known_github else ("email", ((owner and owner.get("email")) or email).lower())
-        
-        # Update aggregate (one record per person across all repos)
         rec = aggregate.get(key)
         if rec is None:
-            aggregate[key] = {
-                "name": name,
-                "email": email,
-                "is_author": bool(is_author),
-                "known_github": known_github,
-                "repos": set([repo]),
-            }
+            aggregate[key] = {"name": name, "email": email, "is_author": is_author, "known_github": known_github, "repos": {repo}}
         else:
-            # promote to author if any occurrence is an author
-            if not rec["is_author"] and is_author:
-                rec["is_author"] = True
-            # accumulate repos
+            rec["is_author"] = rec["is_author"] or is_author
             rec["repos"].add(repo)
-            # fill github if we learn it now
             if known_github and not rec["known_github"]:
                 rec["known_github"] = known_github
-            # prefer non-noreply email (often comming with nicely formatted name, which we therefore update)
             if "users.noreply.github.com" in rec["email"] and "users.noreply.github.com" not in email:
                 rec["name"], rec["email"] = name, email
 
@@ -229,7 +198,7 @@ for repo in REPO_LIST:
     if not os.path.isdir(repo_dir):
         subprocess.run(["git", "clone", f"https://github.com/{repo}", repo_dir], check=True)
     else:
-        subprocess.run(["git", "-C", repo_dir, "pull"], check=True)
+        subprocess.run(["git", "-C", repo_dir, "pull", "--ff-only"], check=True)
     res = subprocess.run(
         ["git", "-C", repo_dir, "log", "--use-mailmap", GIT_LOG_SINCE, GIT_LOG_FORMAT_1],
         check=True, capture_output=True, text=True, encoding="utf-8", errors="replace")

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -68,7 +68,7 @@ def custom_sort_function(item):
 
 try:
     with open(PEOPLE_LIST_FILE, "r", encoding="utf-8") as ymlfile:
-        peopleList = yaml.safe_load(ymlfile) or []
+        current_contributors = yaml.safe_load(ymlfile) or []
 except FileNotFoundError:
     print(f"Error: Could not find {PEOPLE_LIST_FILE}")
     sys.exit(1)
@@ -76,10 +76,10 @@ except yaml.YAMLError as e:
     print(f"Error parsing YAML file {PEOPLE_LIST_FILE}: {e}")
     sys.exit(1)
 
-for person in peopleList:
+for person in current_contributors:
     person.setdefault("repos", [])
 
-names = [person["github"] for person in peopleList if "github" in person]
+current_github_usernames = [person["github"] for person in current_contributors if "github" in person]
 
 
 
@@ -168,7 +168,7 @@ for repo in REPO_LIST:
                 # or if the name exists in an aka
                 # or if the email exists in aka_email
                 flag = False
-                for person in peopleList:
+                for person in current_contributors:
                     if 'email' in person.keys() and 'name' in person.keys():
                         if i[0] == person['name'] and i[1] == person['email']:
                             # we know the person, check if we know the github ID
@@ -201,7 +201,7 @@ for repo in REPO_LIST:
         elif github_commit_url == f"https://api.github.com/repos/{repo}/commits/":
             # this is a case of a co-author
             flag = False
-            for person in peopleList:
+            for person in current_contributors:
                 if 'email' in person.keys() and 'name' in person.keys():
                     if i[0] == person['name'] and i[1] == person['email']:
                             flag = True
@@ -257,14 +257,14 @@ for repo in REPO_LIST:
             flag = False
 
         assert github_username != "__notfound__"
-        if github_username not in names and github_username not in github_newusers and github_username != "__notfound__":
+        if github_username not in current_github_usernames and github_username not in github_newusers and github_username != "__notfound__":
             print("A new contributor!")
             newpersonlist.append(i[0])
             print(f"{i[0]}\t{i[1]}\t{github_username}")
             github_newusers.append(github_username)
             newList.append([i[0], i[1], github_username, [repo]])
-        elif github_username in names:
-            user = [item for item in peopleList if 'github' in item and item['github'] == github_username][0]
+        elif github_username in current_github_usernames:
+            user = [item for item in current_contributors if 'github' in item and item['github'] == github_username][0]
             if repo not in user['repos']:
                 user['repos'].append(repo)
         else:
@@ -289,7 +289,7 @@ retcount = 0
 revcount = 0
 retpersonlist = []
 revpersonlist = []
-for i in peopleList:
+for i in current_contributors:
     if 'github' not in i:
         #co authors
         continue
@@ -314,14 +314,14 @@ for i in newList:
         summarystring += f"- Email not found for {i[0]} ({i[2]})..!\n"
     else:
         np.append({"name": i[0], "email": i[1], "github": i[2], "status": "active", "repos": i[3]})
-peopleList.extend(np)
+current_contributors.extend(np)
 
 np = []
 for i in newCoauthorList:
     np.append({"name": i[0], "email": i[1], "status": "active", "comment": f"Co-author of commit {i[3]}","repos": [i[2]]})
-peopleList.extend(np)
+current_contributors.extend(np)
 
-sortedPeopleList = sorted(peopleList, key= lambda d: d['name'].split()[-1])
+sortedcurrent_contributors = sorted(current_contributors, key= lambda d: d['name'].split()[-1])
 
 
 
@@ -331,9 +331,9 @@ sortedPeopleList = sorted(peopleList, key= lambda d: d['name'].split()[-1])
 
 # save yml to *NEW* file
 # how inefficient is list comprehension ?
-pilist = [dict(sorted(i.items(), key=custom_sort_function)) for i in sortedPeopleList if i['status'] == "pi"]
-activelist = [dict(sorted(i.items(), key=custom_sort_function)) for i in sortedPeopleList if i['status'] == "active"]
-retiredlist = [dict(sorted(i.items(), key=custom_sort_function)) for i in sortedPeopleList if i['status'] == "retired"]
+pilist = [dict(sorted(i.items(), key=custom_sort_function)) for i in sortedcurrent_contributors if i['status'] == "pi"]
+activelist = [dict(sorted(i.items(), key=custom_sort_function)) for i in sortedcurrent_contributors if i['status'] == "active"]
+retiredlist = [dict(sorted(i.items(), key=custom_sort_function)) for i in sortedcurrent_contributors if i['status'] == "retired"]
 
 # Hack copied from https://github.com/yaml/pyyaml/issues/127#issuecomment-525800484
 class MyDumper(yaml.SafeDumper):
@@ -352,7 +352,7 @@ with open('../_data/people_list.yml', 'w') as outfile:
                   "script could not find them in any repo.\n# Retired people only have repo "
                   "information if repo information about them was known when they were\n# active "
                   "(or manually added) by a maintainer.\n\n")
-    yaml.dump(sortedPeopleList, outfile, Dumper=MyDumper, sort_keys = False, allow_unicode=True)
+    yaml.dump(sortedcurrent_contributors, outfile, Dumper=MyDumper, sort_keys = False, allow_unicode=True)
 
 # Produce summary
 summarystring = f"""This PR updates the contributors list based on the latest changes.

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -247,10 +247,12 @@ with open(PEOPLE_LIST_FILE, "w", encoding="utf-8") as f:
     yaml.dump(ordered_people, f, sort_keys=False, allow_unicode=True)
 
 # Write summary
+revived_names = [p.get("name") for p in current_contributors if id(p) in _seen_current and id(p) in _prev_status and _prev_status[id(p)] == "retired"]
 newly_retired_names = [p.get("name") for p in current_contributors if p.get("status") == "retired" and _prev_status.get(id(p)) == "active"]
 summary = (
     "This PR updates the contributors list based on the latest changes.\n"
     f"New contributors : {len(new_names)} | {new_names}\n"
+    f"Revived contributors : {len(revived_names)} | {revived_names}\n"
     f"Newly retired contributors : {len(newly_retired_names)} | {newly_retired_names}\n\n"
     "Summary Notes:\n\n"
 ) + summarystring

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -15,11 +15,49 @@ import yaml
 # 1. Constants
 #######################################
 
-repoList = ["thofma/Hecke.jl", "oscar-system/Oscar.jl", "Nemocas/Nemo.jl",
-            "Nemocas/AbstractAlgebra.jl", "oscar-system/GAP.jl", "oscar-system/Polymake.jl",
-            "oscar-system/Singular.jl", "algebraic-solving/AlgebraicSolving.jl"]
-
 API_KEY = (os.getenv("API_KEY") or os.getenv("GITHUB_TOKEN") or "").strip()
+
+PEOPLE_LIST_FILE = "../_data/people_list.yml"
+SUMMARY_FILE = "../summary.txt"
+REPOS_DIR = "repos"
+
+GIT_LOG_SINCE = "--since=1 year ago"
+GIT_LOG_FORMAT_1 = "--format=%aN <%aE>%n%(trailers:key=Co-authored-by)"
+GIT_LOG_FORMAT_2 = "--format=%H %s %(trailers:key=Co-authored-by)"
+
+REPO_LIST = [
+    "Nemocas/AbstractAlgebra.jl",
+    "algebraic-solving/AlgebraicSolving.jl",
+    "oscar-system/GAP.jl",
+    "thofma/Hecke.jl",
+    "Nemocas/Nemo.jl",
+    "oscar-system/Oscar.jl",
+    "oscar-system/Polymake.jl",
+    "oscar-system/Singular.jl",
+]
+
+STATUS_PI = "pi" # not used yet
+STATUS_ACTIVE = "active" # not used yet
+STATUS_RETIRED = "retired" # not used yet
+
+SORT_WEIGHT = {
+    "name": 0,
+    "affiliation": 1,
+    "email": 2,
+    "github": 3,
+    "website": 4,
+    "paid_by_dfg": 5,
+    "status": 6,
+    "comment": 7,
+    "aka": 8,
+    "aka_email": 9,
+    "repos": 10,
+}
+
+def custom_sort_function(item):
+    name, _ = item
+    sortweight = SORT_WEIGHT
+    return sortweight[name]
 
 
 
@@ -27,7 +65,7 @@ API_KEY = (os.getenv("API_KEY") or os.getenv("GITHUB_TOKEN") or "").strip()
 # 2. Read in intel from people_list.yml
 #######################################
 
-infile = "../_data/people_list.yml"
+infile = PEOPLE_LIST_FILE
 with open(infile, "r") as ymlfile:
     peopleList = yaml.safe_load(ymlfile)
 
@@ -40,20 +78,7 @@ names = [i['github'] for i in peopleList if 'github' in i]
 
 
 #######################################
-# 3. Custom sort function
-#######################################
-
-def custom_sort_function(item):
-    name, _ = item
-    sortweight = {"name": 0, "affiliation": 1, "email": 2, "github": 3, "website": 4,
-                  "paid_by_dfg": 5,"status": 6, "comment": 7, "aka": 8, "aka_email": 9,
-                  "repos": 10}
-    return sortweight[name]
-
-
-
-#######################################
-# 4. Collect (co)authors for each repo
+# 3. Collect (co)authors for each repo
 #######################################
 
 newList = []
@@ -65,10 +90,10 @@ github_userlist = []
 github_username = '__notfound__'
 summarystring = ""
 # grab currently active devs
-if not os.path.isdir("repos"):
-    os.mkdir("repos")
-os.chdir("repos")
-for repo in repoList:
+if not os.path.isdir(REPOS_DIR):
+    os.mkdir(REPOS_DIR)
+os.chdir(REPOS_DIR)
+for repo in REPO_LIST:
     print(f"-------------------------------\nProcessing {repo}...\n-------------------------------")
     print("Fetching updates...")
     # if directory already exists
@@ -82,7 +107,7 @@ for repo in repoList:
         os.chdir(repo.split('/')[-1])
 
     print("Generating list of authors active in past year...")
-    log_cmd = ["git", "log", "--since=1 year ago", "--format=%aN <%aE>%n%(trailers:key=Co-authored-by)"]
+    log_cmd = ["git", "log", GIT_LOG_SINCE, GIT_LOG_FORMAT_1]
     res = subprocess.run(log_cmd, capture_output=True, text=True)
     if res.returncode != 0:
         print("DEBUG git log failed; stderr:", res.stderr.strip())
@@ -197,7 +222,7 @@ for repo in repoList:
                         break
             if not flag:
                 # a co-author we don't know about at all - find a commit hash that mentions them
-                res = subprocess.run(["git", "log", "--since=1 year ago", "--format=%H %s %(trailers:key=Co-authored-by)"],capture_output=True, text=True)
+                res = subprocess.run(["git", "log", GIT_LOG_SINCE, GIT_LOG_FORMAT_2],capture_output=True, text=True)
                 if res.returncode != 0:
                     print("ERROR: git log for co-author failed:", res.stderr.strip())
                     exit(1)
@@ -248,7 +273,7 @@ for repo in repoList:
 
 
 #######################################
-# 5. Sort as new, retired, active
+# 4. Sort as new, retired, active
 #######################################
 
 # mark active / retired
@@ -295,7 +320,7 @@ sortedPeopleList = sorted(peopleList, key= lambda d: d['name'].split()[-1])
 
 
 #######################################
-# 6. Save the findings
+# 5. Save the findings
 #######################################
 
 # save yml to *NEW* file
@@ -330,5 +355,5 @@ Revived contributors : {revcount} | {revpersonlist}
 Newly retired contributors : {retcount} | {retpersonlist}
 New co-authors : {len(newCoauthorList)} | {newCoauthorList}
 \nSummary Notes:\n\n"""+ summarystring
-with open("../summary.txt", 'w') as summaryfile:
+with open(SUMMARY_FILE, 'w') as summaryfile:
     summaryfile.write(summarystring)

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -4,6 +4,7 @@
 import json
 import os
 from email.utils import parseaddr
+import re
 import subprocess
 import sys
 import unicodedata
@@ -28,7 +29,7 @@ BOT_TOKENS = ("github-actions[bot]", "dependabot[bot]", "renovate[bot]", "change
 
 GIT_LOG_SINCE = "--since=1 year ago"
 GIT_LOG_FORMAT_1 = "--format=%aN <%aE>%n%(trailers:unfold,key=Co-authored-by)"
-GIT_LOG_FORMAT_2 = "--format=%H %s %(trailers:key=Co-authored-by)"
+GIT_LOG_FORMAT_2 = "--format=%H %(trailers:only,unfold,separator=|,key=Co-authored-by) %s"
 
 REPO_LIST = [
     "Nemocas/AbstractAlgebra.jl",
@@ -40,6 +41,8 @@ REPO_LIST = [
     "oscar-system/Polymake.jl",
     "oscar-system/Singular.jl",
 ]
+
+HASH_RE = re.compile(r"\b[0-9a-f]{40}\b", re.I)
 
 STATUS_PI = "pi" # not used yet
 STATUS_ACTIVE = "active" # not used yet
@@ -281,7 +284,6 @@ def resolve_github_via_commit(email: str, repos: list[str]) -> str | None:
     return None
 
 def find_coauthor_commit(name: str, email: str, repos: list[str]) -> tuple[str | None, str | None]:
-    """Find any commit that mentions this person in subject or trailers, return (repo, hash)."""
     targets = {t for t in (name.lower(), email.lower()) if t}
     for r in repos:
         repo_path = r.split('/')[-1]
@@ -293,10 +295,11 @@ def find_coauthor_commit(name: str, email: str, repos: list[str]) -> tuple[str |
             continue
         for line in res.stdout.splitlines():
             low = line.lower()
-            if any(t in low for t in targets):
-                parts = line.split()
-                if parts:
-                    return r, parts[0]
+            if not any(t in low for t in targets):
+                continue
+            m = HASH_RE.search(line)
+            if m:
+                return r, m.group(0)
     return None, None
 
 # Precompute current known GitHub usernames
@@ -351,6 +354,7 @@ for rec in unresolved:
         newCoauthorList.append([rec["name"], rec["email"], rrepo, rhash])
     else:
         # Breadcrumb in summary so they don't vanish silently
+        newCoauthorList.append([rec["name"], rec["email"], list(sorted(rec["repos"]))[0], "(no hash found)"])
         summarystring += (
             f"- No GitHub and no commit hash found for {rec['name']} <{rec['email']}>; "
             f"repos={sorted(rec['repos'])}. Skipping for now.\n"

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -308,65 +308,77 @@ def find_coauthor_commit(name: str, email: str, repos: list[str]) -> tuple[str |
 # 8. Post-aggregation enrichment & updates
 ##########################################
 
-# Precompute current known GitHub usernames
-current_github_usernames = [p["github"] for p in current_contributors if "github" in p]
+active_contributors = []   # references to current_contributors entries
+new_contributors = []      # unified schema: {"name","email","repos","github|None","commit_hash|None"}
+_seen_current = set()      # track object identity for retired computation
 
-# Buckets
-newList = []            # list of new contributors: [name, email, github, repos]
-newpersonlist = []      # names for summary
-github_newusers = []    # github handles of new people
-github_userlist = []    # everyone seen as active this run (by github)
-newCoauthorList = []    # [name, email, repo, commit_hash] for unmapped co-authors
-unresolved = []         # aggregate recs without github after all attempts
-
-# 8.1 Resolve GitHub handles where missing, update contributors & build 'newList'
-for rec in aggregate.values():
-    name = rec["name"]
+for key, rec in aggregate.items():
+    name  = rec["name"]
     email = rec["email"]
-    repos = sorted(rec["repos"])
-    gh = rec["known_github"]
+    repos = list(dict.fromkeys(sorted(rec["repos"])))  # de-dup + stable order
+    gh    = rec.get("known_github") or resolve_github_via_commit(email, repos)
 
-    # Try to resolve missing GitHub once, across their repos
-    if not gh:
-        gh = resolve_github_via_commit(email, repos)
+    # Try GitHub match first (fast), then fall back to email/name indices you already built
+    user = None
+    if gh and gh in name_owner:
+        user = name_owner[gh]
+    elif email and email.lower() in email_owner:
+        user = email_owner[email.lower()]
+    else:
+        # As a last resort, try normalized name (already in name_owner)
+        owner_by_name = name_owner.get(_norm_name(name))
+        if owner_by_name:
+            user = owner_by_name
 
-    if gh:
-        # Mark active set
-        if gh not in github_userlist:
-            github_userlist.append(gh)
+    if user:
+        # Merge repos into existing user (preserve order, avoid dups)
+        have = set(user.get("repos", []))
+        for r in repos:
+            if r not in have:
+                user["repos"].append(r)
+                have.add(r)
 
-        if gh in current_github_usernames:
-            # Existing contributor: append repos
-            user = next((it for it in current_contributors if it.get("github") == gh), None)
-            for r in repos:
-                if r not in user["repos"]:
-                    user["repos"].append(r)
+        # If we just learned their GitHub, store it and index it
+        if gh and not user.get("github"):
+            user["github"] = gh
+            name_owner[gh] = user
+
+        # Mark active once
+        uid = id(user)
+        if uid not in _seen_current:
+            _seen_current.add(uid)
+            active_contributors.append(user)
+
+    else:
+        # Brand-new person; authors & coauthors treated uniformly
+        if gh:
+            # New "author"
+            new_contributors.append({
+                "name": name,
+                "email": email,
+                "repos": repos,
+                "github": gh,
+                "commit_hash": None,
+            })
         else:
-            # New contributor
-            newpersonlist.append(name)
-            github_newusers.append(gh)
-            newList.append([name, email, gh, repos])
-    else:
-        # Still unresolved — likely co-author
-        unresolved.append(rec)
+            # New "coauthor" — resolve a representative commit immediately
+            rrepo, rhash = find_coauthor_commit(name, email, repos)
+            if not rhash:
+                rhash = "(no hash found)"
+            new_contributors.append({
+                "name": name,
+                "email": email,
+                "repos": repos,
+                "github": None,
+                "commit_hash": rhash,
+            })
 
-# 8.2 For truly unresolved people, create co-author entries with a representative commit hash (optional but helpful)
-for rec in unresolved:
-    # If they already exist in YAML (co-author entries without github), we won't add dupes now.
-    # We'll just record one commit hash for context.
-    rrepo, rhash = find_coauthor_commit(rec["name"], rec["email"], sorted(rec["repos"]))
-    if rrepo and rhash:
-        newCoauthorList.append([rec["name"], rec["email"], rrepo, rhash])
-    else:
-        # Breadcrumb in summary so they don't vanish silently
-        newCoauthorList.append([rec["name"], rec["email"], list(sorted(rec["repos"]))[0], "(no hash found)"])
-        summarystring += (
-            f"- No GitHub and no commit hash found for {rec['name']} <{rec['email']}>; "
-            f"repos={sorted(rec['repos'])}. Skipping for now.\n"
-        )
+# Retired = in current_contributors but not seen in this run
+retired_contributors = [p for p in current_contributors if id(p) not in _seen_current]
 
 
 
+"""
 ##########################################
 # 9. Compute active/retired/revived and update YAML structure
 ##########################################
@@ -472,3 +484,4 @@ summarystring = (
 
 with open(SUMMARY_FILE, 'w', encoding='utf-8') as summaryfile:
     summaryfile.write(summarystring)
+"""

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -249,7 +249,7 @@ for key, rec in aggregate.items():
 # Snapshot previous statuses for "newly retired" reporting
 _prev_status = {id(p): p.get("status") for p in current_contributors}
 
-# Add new contributors
+# Add new contributors - feels this doubles the effort from lines 238 to 240. Maybe we can avoid this, so new_contributors is no longer needed...
 for rec in new_contributors:
     newp = {"name": rec["name"], "email": rec["email"], "repos": sorted(set(rec["repos"])), "status": "active"}
     if rec["github"]:
@@ -257,6 +257,7 @@ for rec in new_contributors:
     else:
         newp["comment"] = f"Co-author of commit {rec['commit_hash']}"
     current_contributors.append(newp)
+    _seen_current.add(id(newp))
 
 # Set statuses for everyone (PIs untouched)
 for p in current_contributors:

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -352,68 +352,97 @@ retired_contributors = [p for p in current_contributors if id(p) not in _seen_cu
 
 
 
-"""
 ##########################################
-# 9. Compute active/retired/revived and update YAML structure
+# 9. Update YAML structure (add new, set statuses)
 ##########################################
 
-# Add new contributors to YAML (prefer non-noreply emails, as before)
-np = []
-for name, email, gh, repos in newList:
-    if "users.noreply.github.com" in (email or ""):
-        np.append({"name": name, "github": gh, "status": "active", "repos": repos})
-        summarystring += f"- Email not found for {name} ({gh})..!\n"
+# Snapshot previous statuses to compute revive/retire counts
+_prev_status = {id(p): p.get("status") for p in current_contributors}
+
+# Add new contributors to YAML
+# - Authors: include email unless it’s a GH noreply
+# - Coauthors: no github, add a comment with the representative hash
+added_names = []
+added_coauthors = 0
+
+for rec in new_contributors:
+    name   = rec["name"]
+    email  = rec["email"]
+    repos  = sorted(set(rec["repos"]))  # deterministic output
+    gh     = rec["github"]
+    chash  = rec["commit_hash"]
+
+    if gh:
+        # New author
+        if "users.noreply.github.com" in (email or ""):
+            newp = {"name": name, "github": gh, "status": "active", "repos": repos}
+            summarystring += f"- Email not found for {name} ({gh}).\n"
+        else:
+            newp = {"name": name, "email": email, "github": gh, "status": "active", "repos": repos}
+        current_contributors.append(newp)
+        added_names.append(name)
     else:
-        np.append({"name": name, "email": email, "github": gh, "status": "active", "repos": repos})
-current_contributors.extend(np)
+        # New coauthor
+        newp = {
+            "name": name,
+            "email": email,
+            "status": "active",
+            "comment": f"Co-author of commit {chash}",
+            "repos": repos,
+        }
+        current_contributors.append(newp)
+        added_coauthors += 1
+        added_names.append(name)
 
-# Add new co-authors (no github) with a commit reference
-np = []
-for name, email, repo, commit_hash in newCoauthorList:
-    np.append({
-        "name": name,
-        "email": email,
-        "status": "active",
-        "comment": f"Co-author of commit {commit_hash}",
-        "repos": [repo],
-    })
-current_contributors.extend(np)
+# Build a quick lookup for "active this run" using a stable key (github or email)
+def _person_key_for_status(p: dict) -> str:
+    gh = p.get("github")
+    if gh:
+        return f"gh:{gh}"
+    em = p.get("email")
+    return f"email:{(em or '').lower()}"
 
-# Determine revive/retire based on github_userlist
-retcount = 0
+_active_keys = {_person_key_for_status(p) for p in active_contributors}
+
+# Update statuses for existing people (PIs untouched, coauthors-without-github untouched)
 revcount = 0
-retpersonlist = []
+retcount = 0
 revpersonlist = []
+retpersonlist = []
 
 for person in current_contributors:
-    if 'github' not in person:
-        # co-authors without github — leave status alone (treated as active)
-        continue
-    if person.get('status') == 'pi':
+    if person.get("status") == "pi":
         continue  # never touch PIs
-    gh = person.get('github')
-    if gh in github_userlist:
+
+    # Co-authors (no github) keep their status (treat as active-ish), as in the prior logic
+    if not person.get("github"):
+        continue
+
+    key = _person_key_for_status(person)
+    was = person.get("status")
+
+    if key in _active_keys:
         # Active this period
-        if person.get('status') == 'retired':
+        if was == "retired":
             revcount += 1
-            revpersonlist.append(person.get('name'))
-        person['status'] = 'active'
+            revpersonlist.append(person.get("name"))
+        person["status"] = "active"
     else:
-        # Not active this period
-        if person.get('status') == 'active':
+        # Not seen this period → retired
+        if was == "active":
             retcount += 1
-            retpersonlist.append(person.get('name'))
-        person['status'] = 'retired'
+            retpersonlist.append(person.get("name"))
+        person["status"] = "retired"
 
 # Normalize & sort repos per person for deterministic output
 for person in current_contributors:
-    if 'repos' in person and isinstance(person['repos'], list):
-        person['repos'] = sorted(set(person['repos']))
+    if isinstance(person.get("repos"), list):
+        person["repos"] = sorted(set(person["repos"]))
 
 # Final order by surname
 sortedcurrent_contributors = sorted(
     current_contributors,
-    key=lambda d: (d.get('name', '').split()[-1], d.get('name', ''))
+    key=lambda d: (d.get("name", "").split()[-1], d.get("name", ""))
 )
 
 
@@ -427,11 +456,6 @@ def custom_sort_function(item):
     name, _ = item
     sortweight = SORT_WEIGHT
     return sortweight[name]
-
-# dump YAML with your custom sort
-pilist = [dict(sorted(i.items(), key=custom_sort_function)) for i in sortedcurrent_contributors if i.get('status') == "pi"]
-activelist = [dict(sorted(i.items(), key=custom_sort_function)) for i in sortedcurrent_contributors if i.get('status') == "active"]
-retiredlist = [dict(sorted(i.items(), key=custom_sort_function)) for i in sortedcurrent_contributors if i.get('status') == "retired"]
 
 class MyDumper(yaml.SafeDumper):
     def write_line_break(self, data=None):
@@ -447,15 +471,19 @@ with open(PEOPLE_LIST_FILE, 'w', encoding='utf-8') as outfile:
                   "(or manually added) by a maintainer.\n\n")
     yaml.dump(sortedcurrent_contributors, outfile, Dumper=MyDumper, sort_keys=False, allow_unicode=True)
 
+# Build the summary text
+newpersonlist = added_names
+newCoauthorList = [c for c in new_contributors if not c["github"]]
+
 summarystring = (
-    f"This PR updates the contributors list based on the latest changes.\n"
+    "This PR updates the contributors list based on the latest changes.\n"
     f"New contributors : {len(newpersonlist)} | {newpersonlist}\n"
     f"Revived contributors : {revcount} | {revpersonlist}\n"
     f"Newly retired contributors : {retcount} | {retpersonlist}\n"
-    f"New co-authors : {len(newCoauthorList)} | {newCoauthorList}\n\n"
+    f"New co-authors : {len(newCoauthorList)} | "
+    f"{[(c['name'], c['email'], c['commit_hash']) for c in newCoauthorList]}\n\n"
     "Summary Notes:\n\n"
 ) + summarystring
 
 with open(SUMMARY_FILE, 'w', encoding='utf-8') as summaryfile:
     summaryfile.write(summarystring)
-"""

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -78,7 +78,7 @@ SORT_WEIGHT = {
 # 2. Globals (runtime state; mutated)
 ##########################################
 
-# Loaded from PEOPLE_LIST_FILE
+# Contributor lists
 current_contributors = []  # list[dict]
 
 # Alias indices built from current_contributors
@@ -90,6 +90,12 @@ aggregate = {}
 
 # Collected notes (maybe use a list to avoid 'global' rebinding of strings)
 summarystring = ""
+
+# Once we aggregated the current contributors, we fill them into the following buckets
+active_contributors = []   # references to active current_contributors entries
+new_contributors = []      # data of new (co)authors in unified schema: {"name","email","repos","github|None","commit_hash|None"}
+_seen_current = set()      # track object identity for computation of retired contributors
+retired_contributors = []  # references to retired current_contributors entries
 
 
 
@@ -300,43 +306,27 @@ def find_coauthor_commit(name: str, email: str, repos: list[str]) -> tuple[str |
                 continue
             m = HASH_RE.search(line)
             if m:
-                return r, m.group(0)
-    return None, None
+                return m.group(0)
+    return "(no hash found)"
+
 
 
 ##########################################
 # 8. Post-aggregation enrichment & updates
 ##########################################
 
-active_contributors = []   # references to current_contributors entries
-new_contributors = []      # unified schema: {"name","email","repos","github|None","commit_hash|None"}
-_seen_current = set()      # track object identity for retired computation
-
 for key, rec in aggregate.items():
     name  = rec["name"]
     email = rec["email"]
-    repos = list(dict.fromkeys(sorted(rec["repos"])))  # de-dup + stable order
+    repos = rec["repos"]
     gh    = rec.get("known_github") or resolve_github_via_commit(email, repos)
+    user = (name_owner.get(gh) or (email and email_owner.get(email.lower())) or name_owner.get(_norm_name(name)))
 
-    # Try GitHub match first (fast), then fall back to email/name indices you already built
-    user = None
-    if gh and gh in name_owner:
-        user = name_owner[gh]
-    elif email and email.lower() in email_owner:
-        user = email_owner[email.lower()]
-    else:
-        # As a last resort, try normalized name (already in name_owner)
-        owner_by_name = name_owner.get(_norm_name(name))
-        if owner_by_name:
-            user = owner_by_name
-
+    # Existing contributor
     if user:
         # Merge repos into existing user (preserve order, avoid dups)
-        have = set(user.get("repos", []))
-        for r in repos:
-            if r not in have:
-                user["repos"].append(r)
-                have.add(r)
+        have = set(user["repos"])
+        user["repos"].extend(r for r in repos if r not in have)
 
         # If we just learned their GitHub, store it and index it
         if gh and not user.get("github"):
@@ -349,29 +339,13 @@ for key, rec in aggregate.items():
             _seen_current.add(uid)
             active_contributors.append(user)
 
+    # Brand-new person; authors & coauthors treated uniformly
     else:
-        # Brand-new person; authors & coauthors treated uniformly
-        if gh:
-            # New "author"
-            new_contributors.append({
-                "name": name,
-                "email": email,
-                "repos": repos,
-                "github": gh,
-                "commit_hash": None,
-            })
-        else:
-            # New "coauthor" — resolve a representative commit immediately
-            rrepo, rhash = find_coauthor_commit(name, email, repos)
-            if not rhash:
-                rhash = "(no hash found)"
-            new_contributors.append({
-                "name": name,
-                "email": email,
-                "repos": repos,
-                "github": None,
-                "commit_hash": rhash,
-            })
+        if gh:  # New "author"
+            new_contributors.append({"name": name, "email": email, "repos": repos, "github": gh, "commit_hash": None})
+        else:   # New "coauthor" — resolve a representative commit immediately
+            commit_hash = find_coauthor_commit(name, email, repos)
+            new_contributors.append({"name": name, "email": email, "repos": repos, "github": None, "commit_hash": commit_hash})
 
 # Retired = in current_contributors but not seen in this run
 retired_contributors = [p for p in current_contributors if id(p) not in _seen_current]

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -350,12 +350,14 @@ retired_contributors = [p for p in current_contributors if id(p) not in _seen_cu
 
 
 ##########################################
-# 9. Update YAML structure
+# 9. Apply updates and dump output
 ##########################################
 
+# Find the newly retired contributors
 _prev_status = {id(p): p.get("status") for p in current_contributors}
 newly_retired_names = [p.get("name") for p in retired_contributors if _prev_status.get(id(p)) == "active"]
 
+# Apply updates
 for rec in new_contributors:
     newp = {"name": rec["name"], "email": rec["email"], "repos": sorted(set(rec["repos"])), "status": "active"}
     if rec["github"]:
@@ -363,38 +365,29 @@ for rec in new_contributors:
     else:
         newp["comment"] = f"Co-author of commit {rec['commit_hash']}"
     current_contributors.append(newp)
-
 for p in active_contributors:
     p["status"] = "active"
-
 for p in retired_contributors:
     if p.get("status") != "pi":
         p["status"] = "retired"
 
+# Normalize repos list deterministically
 for p in current_contributors:
     p["repos"] = sorted(set(p["repos"]))
 
-sorted_current_contributors = sorted(current_contributors, key=lambda d: (d.get("name", "").split()[-1], d.get("name", "")))
-
+# Final order by surname, then tidy field order
+people_sorted = sorted(current_contributors, key=lambda d: (d.get("name", "").split()[-1], d.get("name", "")))
 def custom_sort_function(item):
     key, _ = item
     return SORT_WEIGHT.get(key, 999)
+ordered_people = [dict(sorted(p.items(), key=custom_sort_function)) for p in people_sorted]
 
-ordered_people = [dict(sorted(person.items(), key=custom_sort_function)) for person in sorted_current_contributors]
-
-
-
-
-##########################################
-# 10. Save the findings to YML file
-##########################################
-
+# Write new content to PEOPLE_LIST_FILE
 class MyDumper(yaml.SafeDumper):
     def write_line_break(self, data=None):
         super().write_line_break(data)
         if len(self.indents) == 1:
             super().write_line_break()
-
 with open(PEOPLE_LIST_FILE, "w", encoding="utf-8") as outfile:
     outfile.write(
         "# It is possible that people marked as 'retired' may have the repo key as an empty array.\n"
@@ -404,18 +397,13 @@ with open(PEOPLE_LIST_FILE, "w", encoding="utf-8") as outfile:
     )
     yaml.dump(ordered_people, outfile, Dumper=MyDumper, sort_keys=False, allow_unicode=True)
 
-
-
-##########################################
-# 11. Write summary text
-##########################################
-
-summarystring = (
+# Create summary in SUMMARY_FILE
+new_names = [rec["name"] for rec in new_contributors]
+summary = (
     "This PR updates the contributors list based on the latest changes.\n"
-    f"New contributors : {len(new_contributors)} | {[rec["name"] for rec in new_contributors]}\n"
+    f"New contributors : {len(new_names)} | {new_names}\n"
     f"Newly retired contributors : {len(newly_retired_names)} | {newly_retired_names}\n\n"
     "Summary Notes:\n\n"
 ) + summarystring
-
 with open(SUMMARY_FILE, "w", encoding="utf-8") as summaryfile:
-    summaryfile.write(summarystring)
+    summaryfile.write(summary)

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -1,18 +1,18 @@
-#######################################
-# 1. Imports
-#######################################
-
 #!/usr/bin/env python3
-import os
+
+# Standard library
 import json
-import yaml
-import requests
+import os
 import subprocess
 
+# Third-party
+import requests
+import yaml
+
 
 
 #######################################
-# 2. Constants
+# 1. Constants
 #######################################
 
 repoList = ["thofma/Hecke.jl", "oscar-system/Oscar.jl", "Nemocas/Nemo.jl",
@@ -24,7 +24,7 @@ API_KEY = (os.getenv("API_KEY") or os.getenv("GITHUB_TOKEN") or "").strip()
 
 
 #######################################
-# 3. Read in intel from people_list.yml
+# 2. Read in intel from people_list.yml
 #######################################
 
 infile = "../_data/people_list.yml"
@@ -40,7 +40,7 @@ names = [i['github'] for i in peopleList if 'github' in i]
 
 
 #######################################
-# 4. Custom sort function
+# 3. Custom sort function
 #######################################
 
 def custom_sort_function(item):
@@ -53,7 +53,7 @@ def custom_sort_function(item):
 
 
 #######################################
-# 5. Collect (co)authors for each repo
+# 4. Collect (co)authors for each repo
 #######################################
 
 newList = []
@@ -248,7 +248,7 @@ for repo in repoList:
 
 
 #######################################
-# 6. Sort as new, retired, active
+# 5. Sort as new, retired, active
 #######################################
 
 # mark active / retired
@@ -295,7 +295,7 @@ sortedPeopleList = sorted(peopleList, key= lambda d: d['name'].split()[-1])
 
 
 #######################################
-# 7. Save the findings
+# 6. Save the findings
 #######################################
 
 # save yml to *NEW* file

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -154,7 +154,7 @@ def _person_key(name: str, email: str):
 
 
 ##########################################
-# 5. Helper: Progress git log
+# 5. Helper: Process git log
 ##########################################
 
 def process_log_into_aggregate(res: str, repo: str) -> None:
@@ -259,41 +259,39 @@ for repo in REPO_LIST:
 
 
 ##########################################
-# 7. Post-aggregation enrichment & updates
+# 7. Helpers to find (co)-author details
 ##########################################
 
+# Try to resolve a GitHub login by finding one authored commit for this email.
 def resolve_github_via_commit(email: str, repos: list[str]) -> str | None:
-    """Try to resolve a GitHub login by finding one authored commit for this email."""
     if not email:
         return None
     for r in repos:
         repo_path = r.split('/')[-1]
         # Find a representative commit authored by this email
-        p = subprocess.run(
-            ["git", "log", f"--author={email}", "--format=%H", "-n", "1"],
-            cwd=repo_path, capture_output=True, text=True, encoding="utf-8"
-        )
-        commit_hash = (p.stdout or "").strip()
+        res = subprocess.run(["git", "log", GIT_LOG_SINCE, f"--author={email}", "--format=%H", "-n", "1"],
+                           cwd=repo_path, capture_output=True, text=True, encoding="utf-8")
+        if res.returncode != 0:
+            continue
+        commit_hash = (res.stdout or "").strip()
         if not commit_hash:
             continue  # no direct authored commit in this repo (could be co-author only)
         url = f"https://api.github.com/repos/{r}/commits/{commit_hash}"
         resp = requests.get(url, headers={"Authorization": f"Bearer {API_KEY}"})
         if resp.status_code != 200:
             continue
-        j = resp.json()
-        author = j.get("author")
+        author = resp.json().get("author")
         if author and author.get("login"):
             return author["login"]
     return None
 
+# Try to resolve a GitHub login by finding one co-authored commit for this email.
 def find_coauthor_commit(name: str, email: str, repos: list[str]) -> tuple[str | None, str | None]:
     targets = {t for t in (name.lower(), email.lower()) if t}
     for r in repos:
         repo_path = r.split('/')[-1]
-        res = subprocess.run(
-            ["git", "log", GIT_LOG_SINCE, GIT_LOG_FORMAT_2],
-            cwd=repo_path, capture_output=True, text=True, encoding="utf-8"
-        )
+        res = subprocess.run(["git", "log", GIT_LOG_SINCE, GIT_LOG_FORMAT_2],
+                             cwd=repo_path, capture_output=True, text=True, encoding="utf-8")
         if res.returncode != 0:
             continue
         for line in res.stdout.splitlines():
@@ -305,18 +303,23 @@ def find_coauthor_commit(name: str, email: str, repos: list[str]) -> tuple[str |
                 return r, m.group(0)
     return None, None
 
+
+##########################################
+# 8. Post-aggregation enrichment & updates
+##########################################
+
 # Precompute current known GitHub usernames
 current_github_usernames = [p["github"] for p in current_contributors if "github" in p]
 
 # Buckets
-newList = []            # [name, email, github, repos]
+newList = []            # list of new contributors: [name, email, github, repos]
 newpersonlist = []      # names for summary
 github_newusers = []    # github handles of new people
 github_userlist = []    # everyone seen as active this run (by github)
 newCoauthorList = []    # [name, email, repo, commit_hash] for unmapped co-authors
 unresolved = []         # aggregate recs without github after all attempts
 
-# 7.1 Resolve GitHub handles where missing, update contributors & build 'newList'
+# 8.1 Resolve GitHub handles where missing, update contributors & build 'newList'
 for rec in aggregate.values():
     name = rec["name"]
     email = rec["email"]
@@ -335,20 +338,19 @@ for rec in aggregate.values():
         if gh in current_github_usernames:
             # Existing contributor: append repos
             user = next((it for it in current_contributors if it.get("github") == gh), None)
-            if user is not None:
-                for r in repos:
-                    if r not in user.setdefault("repos", []):
-                        user["repos"].append(r)
+            for r in repos:
+                if r not in user["repos"]:
+                    user["repos"].append(r)
         else:
             # New contributor
             newpersonlist.append(name)
             github_newusers.append(gh)
             newList.append([name, email, gh, repos])
     else:
-        # Still unresolved — likely co-author or private email
+        # Still unresolved — likely co-author
         unresolved.append(rec)
 
-# 7.2 For truly unresolved people, create co-author entries with a representative commit hash (optional but helpful)
+# 8.2 For truly unresolved people, create co-author entries with a representative commit hash (optional but helpful)
 for rec in unresolved:
     # If they already exist in YAML (co-author entries without github), we won't add dupes now.
     # We'll just record one commit hash for context.
@@ -366,7 +368,7 @@ for rec in unresolved:
 
 
 ##########################################
-# 8. Compute active/retired/revived and update YAML structure
+# 9. Compute active/retired/revived and update YAML structure
 ##########################################
 
 # Add new contributors to YAML (prefer non-noreply emails, as before)
@@ -431,7 +433,7 @@ sortedcurrent_contributors = sorted(
 
 
 ##########################################
-# 9. Save the findings
+# 10. Save the findings
 ##########################################
 
 # custom sort function

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -86,15 +86,57 @@ current_github_usernames = [person["github"] for person in current_contributors 
 
 
 ##########################################
-# 3. Collect (co)authors for each repo
+# 3. Build fast alias lookup
 ##########################################
 
-# 3.1 Change into REPOS_DIR
+email_owner = {}  # lowercased email -> person dict
+name_owner  = {}  # normalized name -> person dict
+
+def _norm_name(s: str) -> str:
+    return " ".join((s or "").split()).lower()
+
+for p in current_contributors:
+    # index primary + aka emails
+    emails = []
+    if p.get("email"):
+        emails.append(p["email"])
+    if p.get("aka_email"):
+        emails.extend(p["aka_email"] or [])
+    for e in emails:
+        email_owner[e.lower()] = p
+
+    # index primary + aka names
+    names = []
+    if p.get("name"):
+        names.append(p["name"])
+    if p.get("aka"):
+        names.extend(p["aka"] or [])
+    for n in names:
+        name_owner[_norm_name(n)] = p
+
+# Helper function to be used below
+def _person_key(name: str, email: str):
+    owner = email_owner.get(email.lower()) or name_owner.get(_norm_name(name))
+    if owner and owner.get("github"):
+        return ("gh", owner["github"])
+    if owner and (owner.get("email") or email):
+        # canonicalize to the owner's primary email if present
+        base = (owner.get("email") or email).lower()
+        return ("email", base)
+    return ("email", email.lower())
+
+
+
+##########################################
+# 4. Collect (co)authors for each repo
+##########################################
+
+# 4.1 Change into REPOS_DIR
 if not os.path.isdir(REPOS_DIR):
     os.mkdir(REPOS_DIR)
 os.chdir(REPOS_DIR)
 
-# 3.2 Initialize variables
+# 4.2 Initialize variables
 newList = []
 newCoauthorList = []
 namelist = []
@@ -104,7 +146,7 @@ github_userlist = []
 github_username = '__notfound__'
 summarystring = ""
 
-# 3.3 Run over repos
+# 4.3 Run over repos
 for repo in REPO_LIST:
 
     print("\n")
@@ -113,7 +155,7 @@ for repo in REPO_LIST:
     print("-------------------------------")
     print("\n")
 
-    # 3.4 Clone the repository/fetch the latest updates
+    # 4.4 Clone the repository/fetch the latest updates
     print("Fetching updates...\n")
     repo_path = repo.split('/')[-1]
     if not os.path.isdir(repo_path):
@@ -122,7 +164,7 @@ for repo in REPO_LIST:
     subprocess.run(["git", "fetch", "--all"], check=True)
     subprocess.run(["git", "pull"], check=True)
 
-    # 3.5 Obtain the log from github
+    # 4.5 Obtain the log from github
     print("Generating list of authors active in past year...\n\n")
     log_cmd = ["git", "log", "--use-mailmap", GIT_LOG_SINCE, GIT_LOG_FORMAT_1]
     res = subprocess.run(log_cmd, capture_output=True, text=True, encoding="utf-8", errors="replace")
@@ -130,7 +172,7 @@ for repo in REPO_LIST:
         print("DEBUG git log failed; stderr:", res.stderr.strip())
         sys.exit(1)
     
-    # 3.6 Process the log, so we obtain pairs of author names and their emails
+    # 4.6 Process the log, so we obtain pairs of author names and their emails
     # Expected lines include:
     #   Cool Author <cool-author-email>
     #   Co-authored-by: Also Cool <another email>
@@ -181,20 +223,45 @@ for repo in REPO_LIST:
             if is_author and not prev[2]:
                 by_email[key] = (name, email, True)
     
-    # Stable, human-friendly order: by name (case-insensitive), then email
+    # Stable, human-friendly order: by name (case-insensitive), then email, finally is_author
     triples = set(by_email.values())
     dnamelist = [[n, e, is_a] for (n, e, is_a) in sorted(triples, key=lambda t: (t[0].lower(), t[1], not t[2]))]
     namelist.extend(dnamelist)
     
-    # 3.7 Process dnamelist further - somehow...
+    # 4.7 dnamelist has items like [name, email, is_author]
+    # Collapse duplicates / aliases into a single record per person
+    by_person = {}  # key -> [name, email, is_author, known_github]
+    for name, email, is_author in dnamelist:
+        owner = email_owner.get(email.lower()) or name_owner.get(_norm_name(name))
+        known_gh = owner.get("github") if owner else None
+        key = _person_key(name, email)
+        prev = by_person.get(key)
+        if prev is None:
+            by_person[key] = [name, email, bool(is_author), known_gh]
+        else:
+            # prefer non-noreply emails for display (and such "better" emails often come with better formatted name)
+            if "users.noreply.github.com" in prev[1] and "users.noreply.github.com" not in email:
+                prev[0], prev[1] = name, email
+            # prefer author if any occurrence is author
+            if not prev[2] and is_author:
+                prev[2] = True
+            # prefer known github if we discover it
+            if known_gh and not prev[3]:
+                prev[3] = known_gh
+
+    # This replaces dnamelist with the consolidated one
+    dnamelist = [[n, e, is_a, gh] for (n, e, is_a, gh) in by_person.values()]
+
+    # 3.8 Process dnamelist further - somehow...
     count = 0
     for i in dnamelist:
         count = count+1
         print(f"Item {count} of {len(dnamelist)}...")
         print(i)
         email = i[1]
-        process = subprocess.run(['git', 'log', f'--author={email}', '--format=%H', '-n 1'],
-                                   capture_output=True)
+        is_author = bool(i[2])
+        known_github = i[3] if len(i) > 3 else None
+        process = subprocess.run(['git', 'log', f'--author={email}', '--format=%H', '-n 1'], capture_output=True)
         hash = process.stdout.decode().strip()
         github_commit_url = f"https://api.github.com/repos/{repo}/commits/{hash}"
         #ask github API for username

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -44,10 +44,6 @@ REPO_LIST = [
 
 HASH_RE = re.compile(r"\b[0-9a-f]{40}\b", re.I)
 
-STATUS_PI = "pi" # not used yet
-STATUS_ACTIVE = "active" # not used yet
-STATUS_RETIRED = "retired" # not used yet
-
 SORT_WEIGHT = {
     "name": 0,
     "affiliation": 1,

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -57,18 +57,11 @@ YAML_HEADER = (
 # 2. Globals (runtime state; mutated)
 ##########################################
 
-# Contributor lists and index structures
-current_contributors = []  # loaded from YAML
-email_owner = {}           # lowercased email to person dict
-name_owner = {}            # normalized name to person dict
-
-# Aggregation state
-aggregate = {}
-summarystring = ""
-
-# Classification buckets
-new_contributors = []
-_seen_current = set()
+current_contributors = []   # loaded from YAML
+email_owner = {}            # dict: lowercased email to person dict
+name_owner = {}             # dict: normalized name to person dict
+aggregate = {}              # list of dicts for all contributors at the time of running this script
+summarystring = ""          # intermediate output for information and debugging
 
 
 ##########################################
@@ -210,67 +203,41 @@ def find_coauthor_commit(name: str, email: str, repos: list[str]) -> str:
 # 7. Post-aggregation enrichment & updates
 ##########################################
 
+_prev_status = {id(p): p.get("status") for p in current_contributors}
+_seen_current = set()
+new_names = []
 for key, rec in aggregate.items():
-    name  = rec["name"]
-    email = rec["email"]
-    repos = rec["repos"]
-    gh    = rec.get("known_github") or find_author_github_nick(email, repos)
+    name, email, repos = rec["name"], rec["email"], rec["repos"]
+    gh = rec.get("known_github") or find_author_github_nick(email, repos)
     user = lookup_user(gh, email, name)
-
-    # Existing contributor
-    if user:
-        # Merge repos into existing user (preserve order, avoid dups)
+    if user:    # Existing contributor
         have = set(user["repos"])
-        user["repos"].extend([r for r in repos if r not in have])
-
-        # If we just learned their GitHub, store it and index it
+        user["repos"].extend(r for r in repos if r not in have)
         if gh and not user.get("github"):
             user["github"] = gh
-            name_owner[gh] = user
+            name_owner[_norm_name(gh)] = user
+        _seen_current.add(id(user))
+    else:   # Brand-new person: add immediately, mark seen, collect name for summary
+        newp = {"name": name, "email": email, "repos": sorted(set(repos)), "status": "active"}
+        if gh:
+            newp["github"] = gh
+            name_owner[_norm_name(gh)] = newp
+        else:
+            newp["comment"] = f"Co-author of commit {find_coauthor_commit(name, email, repos)}"
+        current_contributors.append(newp)
+        _seen_current.add(id(newp))
+        new_names.append(name)
 
-        # Mark active once
-        uid = id(user)
-        if uid not in _seen_current:
-            _seen_current.add(uid)
-
-    # Brand-new person; authors & coauthors treated uniformly
-    else:
-        if gh:  # New "author"
-            new_contributors.append({"name": name, "email": email, "repos": repos, "github": gh, "commit_hash": None})
-        else:   # New "coauthor" — resolve a representative commit immediately
-            commit_hash = find_coauthor_commit(name, email, repos)
-            new_contributors.append({"name": name, "email": email, "repos": repos, "github": None, "commit_hash": commit_hash})
-
-
-##########################################
-# 8. Apply updates and dump output
-##########################################
-
-# Snapshot previous statuses for "newly retired" reporting
-_prev_status = {id(p): p.get("status") for p in current_contributors}
-
-# Add new contributors - feels this doubles the effort from lines 238 to 240. Maybe we can avoid this, so new_contributors is no longer needed...
-for rec in new_contributors:
-    newp = {"name": rec["name"], "email": rec["email"], "repos": sorted(set(rec["repos"])), "status": "active"}
-    if rec["github"]:
-        newp["github"] = rec["github"]
-    else:
-        newp["comment"] = f"Co-author of commit {rec['commit_hash']}"
-    current_contributors.append(newp)
-    _seen_current.add(id(newp))
-
-# Set statuses for everyone (PIs untouched)
 for p in current_contributors:
     if p.get("status") == "pi":
         continue
-    if id(p) in _seen_current:
-        p["status"] = "active"
-    else:
-        p["status"] = "retired"
-
-# Normalize repos list deterministically
-for p in current_contributors:
+    p["status"] = "active" if id(p) in _seen_current else "retired"
     p["repos"] = sorted(set(p["repos"]))
+
+
+##########################################
+# 8. Dump output
+##########################################
 
 # Write new content to PEOPLE_LIST_FILE
 people_sorted = sorted(current_contributors, key=lambda d: (d.get("name", "").split()[-1], d.get("name", "")))
@@ -279,11 +246,11 @@ with open(PEOPLE_LIST_FILE, "w", encoding="utf-8") as f:
     f.write(YAML_HEADER)
     yaml.dump(ordered_people, f, sort_keys=False, allow_unicode=True)
 
-# Create summary in SUMMARY_FILE
+# Write summary
 newly_retired_names = [p.get("name") for p in current_contributors if p.get("status") == "retired" and _prev_status.get(id(p)) == "active"]
 summary = (
     "This PR updates the contributors list based on the latest changes.\n"
-    f"New contributors : {len(new_contributors)} | {[rec["name"] for rec in new_contributors]}\n"
+    f"New contributors : {len(new_names)} | {new_names}\n"
     f"Newly retired contributors : {len(newly_retired_names)} | {newly_retired_names}\n\n"
     "Summary Notes:\n\n"
 ) + summarystring

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -24,6 +24,8 @@ PEOPLE_LIST_FILE = "../_data/people_list.yml"
 SUMMARY_FILE = "../summary.txt"
 REPOS_DIR = "repos"
 
+BOT_TOKENS = ("github-actions[bot]", "dependabot[bot]", "renovate[bot]", "changelog[bot]")
+
 GIT_LOG_SINCE = "--since=1 year ago"
 GIT_LOG_FORMAT_1 = "--format=%aN <%aE>%n%(trailers:unfold,key=Co-authored-by)"
 GIT_LOG_FORMAT_2 = "--format=%H %s %(trailers:key=Co-authored-by)"
@@ -136,66 +138,57 @@ if not os.path.isdir(REPOS_DIR):
     os.mkdir(REPOS_DIR)
 os.chdir(REPOS_DIR)
 
-# 4.2 Run over repos
+# 4.2 Run over repos to aggreate authors and coauthors
 summarystring = ""
 aggregate = {}      # key -> {'name','email','is_author','known_github','repos': set()}
 for repo in REPO_LIST:
 
-    print("\n")
-    print("-------------------------------")
     print(f"Processing {repo}...")
-    print("-------------------------------")
-    print("\n")
-
-    # 4.3 Clone the repository/fetch the latest updates
-    print("Fetching updates...\n")
     repo_path = repo.split('/')[-1]
     if not os.path.isdir(repo_path):
         subprocess.run(["git", "clone", f"https://github.com/{repo}"], check=True)
     os.chdir(repo_path)
     subprocess.run(["git", "fetch", "--all"], check=True)
     subprocess.run(["git", "pull"], check=True)
-
-    # 4.4 Obtain the log from github
-    print("Generating list of authors active in past year...\n\n")
     log_cmd = ["git", "log", "--use-mailmap", GIT_LOG_SINCE, GIT_LOG_FORMAT_1]
     res = subprocess.run(log_cmd, capture_output=True, text=True, encoding="utf-8", errors="replace")
+    os.chdir("..")
     if res.returncode != 0:
         print("DEBUG git log failed; stderr:", res.stderr.strip())
         sys.exit(1)
     
-    # 4.5 Process the log, so we obtain pairs of author names and their emails
-    # Expected lines include:
-    #   Cool Author <cool-author-email>
-    #   Co-authored-by: Also Cool <another email>
-    by_email = {}        # email_lower -> (name, email, is_author)
+    # 4.5 Process the log and update aggregate accordingly
     for raw in res.stdout.splitlines():
 
-        # Initial processing of the line and skipping if needed
+        # Prepare the line and skip if empty
         line = raw.strip()
+        if not line:
+            continue
+
+        # Identify co-authors
         is_author = True
         if line.lower().startswith("co-authored-by:"):
             line = line.split(":", 1)[1].strip()
             is_author = False
-        if not line:
-            continue
+
+        # Skip bots and non-address lines
         lower_line = line.lower()
-        if any(b in lower_line for b in ("github-actions[bot]", "dependabot[bot]", "renovate[bot]", "changelog[bot]")):
+        if any(b in lower_line for b in BOT_TOKENS):
             continue
         if "[bot]" in lower_line:
-            summarystring += f"- Skipping expected bot line in {repo}: {line!r}\n"
+            summarystring += f"- Skipping suspected bot line in {repo}: {line!r}\n"
             continue
         if "<" not in line or ">" not in line:
             summarystring += f"- Skipping non-address line in {repo}: {line!r}\n"
             continue
-        
-        # Parse to obtain name and email
+
+        # Parse "Name <email>"
         name, email = parseaddr(line)
         name = " ".join(unicodedata.normalize("NFKC", name).split())
         email = unicodedata.normalize("NFKC", email).strip()
-        
+
         # Validate
-        if (not email) and (not name):
+        if not email and not name:
             summarystring += f"- Missing name and email in {repo}; line={line!r}; skipping\n"
             continue
         if not email:
@@ -205,47 +198,14 @@ for repo in REPO_LIST:
             summarystring += f"- Missing name for '{email}' in {repo}; skipping\n"
             continue
 
-        # Dedupe
-        key = email.lower()
-        prev = by_email.get(key)
-        if prev is None:
-            by_email[key] = (name, email, is_author)
-        else:
-            # upgrade to author if any occurrence is an author
-            if is_author and not prev[2]:
-                by_email[key] = (name, email, True)
-    
-    # Stable, human-friendly order: by name (case-insensitive), then email, finally is_author
-    triples = set(by_email.values())
-    dnamelist = [[n, e, is_a] for (n, e, is_a) in sorted(triples, key=lambda t: (t[0].lower(), t[1], not t[2]))]
-    
-    # 4.6 dnamelist has items like [name, email, is_author]
-    # Collapse duplicates / aliases into a single record per person
-    by_person = {}  # key -> [name, email, is_author, known_github]
-    for name, email, is_author in dnamelist:
+        # Alias resolution from PEOPLE_LIST_FILE (aka/aka_email)
         owner = email_owner.get(email.lower()) or name_owner.get(_norm_name(name))
-        known_gh = owner.get("github") if owner else None
-        key = _person_key(name, email)
-        prev = by_person.get(key)
-        if prev is None:
-            by_person[key] = [name, email, bool(is_author), known_gh]
-        else:
-            # prefer non-noreply emails for display (and such "better" emails often come with better formatted name)
-            if "users.noreply.github.com" in prev[1] and "users.noreply.github.com" not in email:
-                prev[0], prev[1] = name, email
-            # prefer author if any occurrence is author
-            if not prev[2] and is_author:
-                prev[2] = True
-            # prefer known github if we discover it
-            if known_gh and not prev[3]:
-                prev[3] = known_gh
+        known_github = owner.get("github") if owner else None
 
-    # This replaces dnamelist with the consolidated one
-    dnamelist = [[n, e, is_a, gh] for (n, e, is_a, gh) in by_person.values()]
-
-    # 4.7 Aggregate across repos (no API calls here)
-    for name, email, is_author, known_github in dnamelist:
+        # Person key: prefer github if known; else canonical email via owner; else raw email
         key = _person_key(name, email)
+
+        # Update aggregate (one record per person across all repos)
         rec = aggregate.get(key)
         if rec is None:
             aggregate[key] = {
@@ -256,18 +216,17 @@ for repo in REPO_LIST:
                 "repos": set([repo]),
             }
         else:
-            # merge flags and better data
-            if not rec["is_author"] and bool(is_author):
+            # promote to author if any occurrence is an author
+            if not rec["is_author"] and is_author:
                 rec["is_author"] = True
+            # accumulate repos
             rec["repos"].add(repo)
+            # fill github if we learn it now
             if known_github and not rec["known_github"]:
                 rec["known_github"] = known_github
-            # prefer non-noreply email (and the name that came with it)
+            # prefer non-noreply email (often comming with nicely formatted name, which we therefore update)
             if "users.noreply.github.com" in rec["email"] and "users.noreply.github.com" not in email:
                 rec["name"], rec["email"] = name, email
-    
-    # 4.8 Go one step up, to prepare the scan in the next repository
-    os.chdir("..")
 
 
 

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -12,9 +12,9 @@ import yaml
 
 
 
-#######################################
+##########################################
 # 1. Constants
-#######################################
+##########################################
 
 API_KEY = (os.getenv("API_KEY") or os.getenv("GITHUB_TOKEN") or "").strip()
 
@@ -62,9 +62,9 @@ def custom_sort_function(item):
 
 
 
-#######################################
-# 2. Read in intel from people_list.yml
-#######################################
+##########################################
+# 2. Read information from people_list.yml
+##########################################
 
 try:
     with open(PEOPLE_LIST_FILE, "r", encoding="utf-8") as ymlfile:
@@ -83,9 +83,9 @@ current_github_usernames = [person["github"] for person in current_contributors 
 
 
 
-#######################################
+##########################################
 # 3. Collect (co)authors for each repo
-#######################################
+##########################################
 
 newList = []
 newCoauthorList = []
@@ -278,9 +278,9 @@ for repo in REPO_LIST:
 
 
 
-#######################################
+##########################################
 # 4. Sort as new, retired, active
-#######################################
+##########################################
 
 # mark active / retired
 # if PI, don't touch them
@@ -325,9 +325,9 @@ sortedcurrent_contributors = sorted(current_contributors, key= lambda d: d['name
 
 
 
-#######################################
+##########################################
 # 5. Save the findings
-#######################################
+##########################################
 
 # save yml to *NEW* file
 # how inefficient is list comprehension ?

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 # Standard library
-import json
 import os
 from email.utils import parseaddr
 import re
@@ -127,32 +126,22 @@ for person in current_contributors:
 ##########################################
 
 def _norm_name(s: str) -> str:
-    return " ".join((s or "").split()).lower()
+    return " ".join((s or "").split()).casefold()
 
 for p in current_contributors:
-    # index primary + aka emails
-    emails = []
     if p.get("email"):
-        emails.append(p["email"])
-    if p.get("aka_email"):
-        emails.extend(p["aka_email"])
-    for e in emails:
-        email_owner[e.lower()] = p
-
-    # index primary + aka names
-    names = []
+        email_owner[p.get("email").casefold()] = p
+    for ae in (p.get("aka_email") or ()):
+        email_owner[ae.casefold()] = p
     if p.get("name"):
-        names.append(p["name"])
-    if p.get("aka"):
-        names.extend(p["aka"])
+        name_owner[_norm_name(p.get("name"))] = p
+    for an in (p.get("aka") or ()):
+        name_owner[_norm_name(an)] = p
     if p.get("github"):
-        names.append(p["github"])
-    for n in names:
-        name_owner[_norm_name(n)] = p
+        name_owner[_norm_name(p.get("github"))] = p
 
 def lookup_user(gh, email, name):
-    global email_owner, name_owner
-    return ((gh and name_owner.get(gh.lower())) or (email and email_owner.get(email.lower())) or name_owner.get(_norm_name(name)))
+    return ((gh and name_owner.get(_norm_name(gh))) or (email and email_owner.get(email.casefold())) or name_owner.get(_norm_name(name)))
 
 
 
@@ -289,7 +278,7 @@ def resolve_github_via_commit(email: str, repos: list[str]) -> str | None:
     return None
 
 # Try to resolve a GitHub login by finding one co-authored commit for this email.
-def find_coauthor_commit(name: str, email: str, repos: list[str]) -> tuple[str | None, str | None]:
+def find_coauthor_commit(name: str, email: str, repos: list[str]) -> str:
     targets = {t for t in (name.lower(), email.lower()) if t}
     for r in repos:
         repo_path = r.split('/')[-1]

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -16,22 +16,26 @@ import yaml
 
 
 ##########################################
-# 1. Constants
+# 1. Constants (static configuration)
 ##########################################
 
+# Derive absolute paths once so chdir() doesn’t bite us later.
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+PROJECT_ROOT = os.path.abspath(os.path.join(BASE_DIR, ".."))
+REPOS_DIR = os.path.join(PROJECT_ROOT, "repos")
+PEOPLE_LIST_FILE = os.path.join(PROJECT_ROOT, "_data", "people_list.yml")
+SUMMARY_FILE = os.path.join(PROJECT_ROOT, "summary.txt")
+
+# Auth
 API_KEY = (os.getenv("API_KEY") or os.getenv("GITHUB_TOKEN") or "").strip()
 
-PEOPLE_LIST_FILE = "../_data/people_list.yml"
-SUMMARY_FILE = "../summary.txt"
-REPOS_DIR = "repos"
-
-BOT_TOKENS = ("github-actions[bot]", "dependabot[bot]", "renovate[bot]", "changelog[bot]")
-
+# Git config
 GIT_LOG_SINCE = "--since=1 year ago"
 GIT_LOG_FORMAT_1 = "--format=%aN <%aE>%n%(trailers:unfold,key=Co-authored-by)"
 GIT_LOG_FORMAT_2 = "--format=%H %(trailers:only,unfold,separator=|,key=Co-authored-by) %s"
 
-REPO_LIST = [
+# Repositories to scan (tuple to emphasize immutability)
+REPO_LIST = (
     "Nemocas/AbstractAlgebra.jl",
     "algebraic-solving/AlgebraicSolving.jl",
     "oscar-system/GAP.jl",
@@ -40,10 +44,20 @@ REPO_LIST = [
     "oscar-system/Oscar.jl",
     "oscar-system/Polymake.jl",
     "oscar-system/Singular.jl",
-]
+)
 
+# Bots we ignore
+BOT_TOKENS = (
+    "github-actions[bot]",
+    "dependabot[bot]",
+    "renovate[bot]",
+    "changelog[bot]",
+)
+
+# Regexes
 HASH_RE = re.compile(r"\b[0-9a-f]{40}\b", re.I)
 
+# Display/sort preferences
 SORT_WEIGHT = {
     "name": 0,
     "affiliation": 1,
@@ -58,30 +72,23 @@ SORT_WEIGHT = {
     "repos": 10,
 }
 
-def custom_sort_function(item):
-    name, _ = item
-    sortweight = SORT_WEIGHT
-    return sortweight[name]
-
 
 
 ##########################################
-# 2. Global variables
+# 2. Globals (runtime state; mutated)
 ##########################################
 
-# Step 3: The information on contributors, that is currently saved in PEOPLE_LIST_FILE.
-#current_contributors
+# Loaded from PEOPLE_LIST_FILE
+current_contributors = []  # list[dict]
 
-# Step 4: People come with alias emails. This dict will tell us the owner of a given email, provided our PEOPLE_LIST_FILE knows about this
-email_owner = {}  # lowercased email -> person dict
+# Alias indices built from current_contributors
+email_owner = {}   # lowercased email -> person dict
+name_owner  = {}   # normalized name  -> person dict
 
-# Step 4: Same as email_owner, but with name alias instead
-name_owner  = {}  # normalized name -> person dict
+# Aggregate across repos: key -> {'name','email','is_author','known_github','repos': set()}
+aggregate = {}
 
-# Step 5: A dict, in which we store information about the current authors and coauthors
-aggregate = {}      # key -> {'name','email','is_author','known_github','repos': set()}
-
-# Step 5: This string will collect warnings encountered during execution
+# Collected notes (maybe use a list to avoid 'global' rebinding of strings)
 summarystring = ""
 
 
@@ -427,6 +434,12 @@ sortedcurrent_contributors = sorted(
 # 9. Save the findings
 ##########################################
 
+# custom sort function
+def custom_sort_function(item):
+    name, _ = item
+    sortweight = SORT_WEIGHT
+    return sortweight[name]
+
 # dump YAML with your custom sort
 pilist = [dict(sorted(i.items(), key=custom_sort_function)) for i in sortedcurrent_contributors if i.get('status') == "pi"]
 activelist = [dict(sorted(i.items(), key=custom_sort_function)) for i in sortedcurrent_contributors if i.get('status') == "active"]
@@ -438,8 +451,7 @@ class MyDumper(yaml.SafeDumper):
         if len(self.indents) == 1:
             super().write_line_break()
 
-os.chdir("..")
-with open('../_data/people_list.yml', 'w', encoding='utf-8') as outfile:
+with open(PEOPLE_LIST_FILE, 'w', encoding='utf-8') as outfile:
     outfile.write("# It is possible that people marked as 'retired' may have the repo key as an "
                   "empty array.\n# This is because people are marked as retired if the update "
                   "script could not find them in any repo.\n# Retired people only have repo "

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -145,10 +145,8 @@ def process_log_into_aggregate(res: str, repo: str) -> None:
         line = raw.strip()
         if not line: continue
 
-        is_author = True
         if line.lower().startswith("co-authored-by:"):
             line = line.split(":", 1)[1].strip()
-            is_author = False
 
         low = line.lower()
         if any(b in low for b in BOT_TOKENS):
@@ -173,9 +171,8 @@ def process_log_into_aggregate(res: str, repo: str) -> None:
 
         rec = aggregate.get(key)
         if rec is None:
-            aggregate[key] = {"name": name, "email": email, "is_author": is_author, "known_github": known_github, "repos": {repo}}
+            aggregate[key] = {"name": name, "email": email, "known_github": known_github, "repos": {repo}}
         else:
-            rec["is_author"] = rec["is_author"] or is_author
             rec["repos"].add(repo)
             if known_github and not rec["known_github"]:
                 rec["known_github"] = known_github

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -192,12 +192,6 @@ for repo in REPO_LIST:
         count = count+1
         print(f"Item {count} of {len(dnamelist)}...")
         print(i)
-        if i[0] == 'dependabot[bot]':
-            print("Skipping dependabot!")
-            continue
-        if "[bot]" in i[0]:
-            print(f"Skipping suspected bot {i[0]}")
-            continue
         email = i[1]
         process = subprocess.run(['git', 'log', f'--author={email}', '--format=%H', '-n 1'],
                                    capture_output=True)

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -3,8 +3,10 @@
 # Standard library
 import json
 import os
+from email.utils import parseaddr
 import subprocess
 import sys
+import unicodedata
 
 # Third-party
 import requests
@@ -23,7 +25,7 @@ SUMMARY_FILE = "../summary.txt"
 REPOS_DIR = "repos"
 
 GIT_LOG_SINCE = "--since=1 year ago"
-GIT_LOG_FORMAT_1 = "--format=%aN <%aE>%n%(trailers:key=Co-authored-by)"
+GIT_LOG_FORMAT_1 = "--format=%aN <%aE>%n%(trailers:unfold,key=Co-authored-by)"
 GIT_LOG_FORMAT_2 = "--format=%H %s %(trailers:key=Co-authored-by)"
 
 REPO_LIST = [
@@ -87,6 +89,12 @@ current_github_usernames = [person["github"] for person in current_contributors 
 # 3. Collect (co)authors for each repo
 ##########################################
 
+# 3.1 Change into REPOS_DIR
+if not os.path.isdir(REPOS_DIR):
+    os.mkdir(REPOS_DIR)
+os.chdir(REPOS_DIR)
+
+# 3.2 Initialize variables
 newList = []
 newCoauthorList = []
 namelist = []
@@ -95,50 +103,90 @@ github_newusers = []
 github_userlist = []
 github_username = '__notfound__'
 summarystring = ""
-# grab currently active devs
-if not os.path.isdir(REPOS_DIR):
-    os.mkdir(REPOS_DIR)
-os.chdir(REPOS_DIR)
-for repo in REPO_LIST:
-    print(f"-------------------------------\nProcessing {repo}...\n-------------------------------")
-    print("Fetching updates...")
-    # if directory already exists
-    if os.path.isdir(repo.split('/')[-1]):
-        os.chdir(repo.split('/')[-1])
-        subprocess.run(["git", "fetch", "--all"], check=True)
-        subprocess.run(["git", "pull"], check=True)
-    # if directory needs to be freshly cloned
-    else:
-        subprocess.run(["git", "clone", f"https://github.com/{repo}"], check=True)
-        os.chdir(repo.split('/')[-1])
 
-    print("Generating list of authors active in past year...")
-    log_cmd = ["git", "log", GIT_LOG_SINCE, GIT_LOG_FORMAT_1]
-    res = subprocess.run(log_cmd, capture_output=True, text=True)
+# 3.3 Run over repos
+for repo in REPO_LIST:
+
+    print("\n")
+    print("-------------------------------")
+    print(f"Processing {repo}...")
+    print("-------------------------------")
+    print("\n")
+
+    # 3.4 Clone the repository/fetch the latest updates
+    print("Fetching updates...\n")
+    repo_path = repo.split('/')[-1]
+    if not os.path.isdir(repo_path):
+        subprocess.run(["git", "clone", f"https://github.com/{repo}"], check=True)
+    os.chdir(repo_path)
+    subprocess.run(["git", "fetch", "--all"], check=True)
+    subprocess.run(["git", "pull"], check=True)
+
+    # 3.5 Obtain the log from github
+    print("Generating list of authors active in past year...\n\n")
+    log_cmd = ["git", "log", "--use-mailmap", GIT_LOG_SINCE, GIT_LOG_FORMAT_1]
+    res = subprocess.run(log_cmd, capture_output=True, text=True, encoding="utf-8", errors="replace")
     if res.returncode != 0:
         print("DEBUG git log failed; stderr:", res.stderr.strip())
-        exit(-1)
-    else:
-        dset = set()
-        for raw in res.stdout.splitlines():
-            # res.stdout.splitlines() reads as follows:
-            # Cool Author <cool-author-email>
-            # Co-authored-by: Also Cool <another email>
-            # Process each row, so we obtain pairs of author names and their emails
-            line = raw.strip()
-            if line == "":
-                continue
-            if line.lower().startswith("co-authored-by:"):
-                line = line.split(":", 1)[1].strip()
-            if "<" in line and ">" in line:
-                name = line.split("<")[0].strip()
-                email = line.split("<", 1)[1].split(">", 1)[0].strip()
-                if (name != "") and (email != ""):
-                    dset.add((name, email))
-        dnamelist = [[n, e] for (n, e) in sorted(dset)]
-    print(dnamelist)
+        sys.exit(1)
+    
+    # 3.6 Process the log, so we obtain pairs of author names and their emails
+    # Expected lines include:
+    #   Cool Author <cool-author-email>
+    #   Co-authored-by: Also Cool <another email>
+    by_email = {}        # email_lower -> (name, email, is_author)
+    for raw in res.stdout.splitlines():
 
+        # Initial processing of the line and skipping if needed
+        line = raw.strip()
+        is_author = True
+        if line.lower().startswith("co-authored-by:"):
+            line = line.split(":", 1)[1].strip()
+            is_author = False
+        if not line:
+            continue
+        lower_line = line.lower()
+        if any(b in lower_line for b in ("github-actions[bot]", "dependabot[bot]", "renovate[bot]", "changelog[bot]")):
+            continue
+        if "[bot]" in lower_line:
+            summarystring += f"- Skipping expected bot line in {repo}: {line!r}\n"
+            continue
+        if "<" not in line or ">" not in line:
+            summarystring += f"- Skipping non-address line in {repo}: {line!r}\n"
+            continue
+        
+        # Parse to obtain name and email
+        name, email = parseaddr(line)
+        name = " ".join(unicodedata.normalize("NFKC", name).split())
+        email = unicodedata.normalize("NFKC", email).strip()
+        
+        # Validate
+        if (not email) and (not name):
+            summarystring += f"- Missing name and email in {repo}; line={line!r}; skipping\n"
+            continue
+        if not email:
+            summarystring += f"- Missing email for '{name}' in {repo}; skipping\n"
+            continue
+        if not name:
+            summarystring += f"- Missing name for '{email}' in {repo}; skipping\n"
+            continue
+
+        # Dedupe
+        key = email.lower()
+        prev = by_email.get(key)
+        if prev is None:
+            by_email[key] = (name, email, is_author)
+        else:
+            # upgrade to author if any occurrence is an author
+            if is_author and not prev[2]:
+                by_email[key] = (name, email, True)
+    
+    # Stable, human-friendly order: by name (case-insensitive), then email
+    triples = set(by_email.values())
+    dnamelist = [[n, e, is_a] for (n, e, is_a) in sorted(triples, key=lambda t: (t[0].lower(), t[1], not t[2]))]
     namelist.extend(dnamelist)
+    
+    # 3.7 Process dnamelist further - somehow...
     count = 0
     for i in dnamelist:
         count = count+1

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -47,6 +47,12 @@ HASH_RE = re.compile(r"\b[0-9a-f]{40}\b", re.I)
 SORT_WEIGHT = {"name": 0, "affiliation": 1, "email": 2, "github": 3, "website": 4, "paid_by_dfg": 5,
                "status": 6, "comment": 7, "aka": 8, "aka_email": 9, "repos": 10}
 
+YAML_HEADER = (
+    "# It is possible that people marked as 'retired' may have the repo key as an empty array.\n"
+    "# This is because people are marked as retired if the update script could not find them in any repo.\n"
+    "# Retired people only have repo information if repo information about them was known when they were\n"
+    "# active (or manually added) by a maintainer.\n\n")
+
 
 
 ##########################################
@@ -287,14 +293,9 @@ class MyDumper(yaml.SafeDumper):
         super().write_line_break(data)
         if len(self.indents) == 1:
             super().write_line_break()
-with open(PEOPLE_LIST_FILE, "w", encoding="utf-8") as outfile:
-    outfile.write(
-        "# It is possible that people marked as 'retired' may have the repo key as an empty array.\n"
-        "# This is because people are marked as retired if the update script could not find them in any repo.\n"
-        "# Retired people only have repo information if repo information about them was known when they were\n"
-        "# active (or manually added) by a maintainer.\n\n"
-    )
-    yaml.dump(ordered_people, outfile, Dumper=MyDumper, sort_keys=False, allow_unicode=True)
+with open(PEOPLE_LIST_FILE, "w", encoding="utf-8") as f:
+    f.write(YAML_HEADER)
+    yaml.dump(ordered_people, f, Dumper=MyDumper, sort_keys=False, allow_unicode=True)
 
 # Create summary in SUMMARY_FILE
 new_names = [rec["name"] for rec in new_contributors]

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -136,17 +136,8 @@ if not os.path.isdir(REPOS_DIR):
     os.mkdir(REPOS_DIR)
 os.chdir(REPOS_DIR)
 
-# 4.2 Initialize variables
-newList = []
-newCoauthorList = []
-namelist = []
-newpersonlist = []
-github_newusers = []
-github_userlist = []
-github_username = '__notfound__'
+# 4.2 Run over repos
 summarystring = ""
-
-# 4.3 Run over repos
 aggregate = {}      # key -> {'name','email','is_author','known_github','repos': set()}
 for repo in REPO_LIST:
 
@@ -156,7 +147,7 @@ for repo in REPO_LIST:
     print("-------------------------------")
     print("\n")
 
-    # 4.4 Clone the repository/fetch the latest updates
+    # 4.3 Clone the repository/fetch the latest updates
     print("Fetching updates...\n")
     repo_path = repo.split('/')[-1]
     if not os.path.isdir(repo_path):
@@ -165,7 +156,7 @@ for repo in REPO_LIST:
     subprocess.run(["git", "fetch", "--all"], check=True)
     subprocess.run(["git", "pull"], check=True)
 
-    # 4.5 Obtain the log from github
+    # 4.4 Obtain the log from github
     print("Generating list of authors active in past year...\n\n")
     log_cmd = ["git", "log", "--use-mailmap", GIT_LOG_SINCE, GIT_LOG_FORMAT_1]
     res = subprocess.run(log_cmd, capture_output=True, text=True, encoding="utf-8", errors="replace")
@@ -173,7 +164,7 @@ for repo in REPO_LIST:
         print("DEBUG git log failed; stderr:", res.stderr.strip())
         sys.exit(1)
     
-    # 4.6 Process the log, so we obtain pairs of author names and their emails
+    # 4.5 Process the log, so we obtain pairs of author names and their emails
     # Expected lines include:
     #   Cool Author <cool-author-email>
     #   Co-authored-by: Also Cool <another email>
@@ -227,9 +218,8 @@ for repo in REPO_LIST:
     # Stable, human-friendly order: by name (case-insensitive), then email, finally is_author
     triples = set(by_email.values())
     dnamelist = [[n, e, is_a] for (n, e, is_a) in sorted(triples, key=lambda t: (t[0].lower(), t[1], not t[2]))]
-    namelist.extend(dnamelist)
     
-    # 4.7 dnamelist has items like [name, email, is_author]
+    # 4.6 dnamelist has items like [name, email, is_author]
     # Collapse duplicates / aliases into a single record per person
     by_person = {}  # key -> [name, email, is_author, known_github]
     for name, email, is_author in dnamelist:
@@ -253,7 +243,7 @@ for repo in REPO_LIST:
     # This replaces dnamelist with the consolidated one
     dnamelist = [[n, e, is_a, gh] for (n, e, is_a, gh) in by_person.values()]
 
-    # 4.8 Aggregate across repos (no API calls here)
+    # 4.7 Aggregate across repos (no API calls here)
     for name, email, is_author, known_github in dnamelist:
         key = _person_key(name, email)
         rec = aggregate.get(key)
@@ -276,12 +266,15 @@ for repo in REPO_LIST:
             if "users.noreply.github.com" in rec["email"] and "users.noreply.github.com" not in email:
                 rec["name"], rec["email"] = name, email
     
-    # 4.9 Go one step up, to prepare the scan in the next repository
+    # 4.8 Go one step up, to prepare the scan in the next repository
     os.chdir("..")
 
-# 4.10 Enrich once across the consolidated people (skip API for now)
+# 4.9 Enrich once across the consolidated people (skip API for now)
 unresolved = []
-
+newList = []
+newpersonlist = []
+github_newusers = []
+github_userlist = []
 for key, rec in aggregate.items():
     name = rec["name"]
     email = rec["email"]
@@ -318,8 +311,10 @@ for rec in unresolved:
 
 
 ##########################################
-# 4. Sort as new, retired, active
+# 5. Sort as new, retired, active
 ##########################################
+
+newCoauthorList = []
 
 # mark active / retired
 # if PI, don't touch them
@@ -365,7 +360,7 @@ sortedcurrent_contributors = sorted(current_contributors, key= lambda d: d['name
 
 
 ##########################################
-# 5. Save the findings
+# 6. Save the findings
 ##########################################
 
 # save yml to *NEW* file

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -150,16 +150,9 @@ for p in current_contributors:
     for n in names:
         name_owner[_norm_name(n)] = p
 
-# Helper function to be used below
-def _person_key(name: str, email: str):
-    owner = email_owner.get(email.lower()) or name_owner.get(_norm_name(name))
-    if owner and owner.get("github"):
-        return ("gh", owner["github"])
-    if owner and (owner.get("email") or email):
-        # canonicalize to the owner's primary email if present
-        base = (owner.get("email") or email).lower()
-        return ("email", base)
-    return ("email", email.lower())
+def lookup_user(gh, email, name):
+    global email_owner, name_owner
+    return ((gh and name_owner.get(gh.lower())) or (email and email_owner.get(email.lower())) or name_owner.get(_norm_name(name)))
 
 
 
@@ -216,8 +209,8 @@ def process_log_into_aggregate(res: str, repo: str) -> None:
         known_github = owner.get("github") if owner else None
 
         # Person key: prefer github if known; else canonical email via owner; else raw email
-        key = _person_key(name, email)
-
+        key = ("gh", known_github.lower()) if known_github else ("email", ((owner and owner.get("email")) or email).lower())
+        
         # Update aggregate (one record per person across all repos)
         rec = aggregate.get(key)
         if rec is None:
@@ -324,11 +317,7 @@ for key, rec in aggregate.items():
     email = rec["email"]
     repos = rec["repos"]
     gh    = rec.get("known_github") or resolve_github_via_commit(email, repos)
-    user = (
-        (gh and name_owner.get(_norm_name(gh)))
-        or (email and email_owner.get(email.lower()))
-        or name_owner.get(_norm_name(name))
-    )
+    user = lookup_user(gh, email, name)
 
     # Existing contributor
     if user:

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -229,22 +229,22 @@ def process_log_into_aggregate(res: str, repo: str) -> None:
 # 6. Find (co)authors of all repos
 ##########################################
 
-if not os.path.isdir(REPOS_DIR):
-    os.mkdir(REPOS_DIR)
-os.chdir(REPOS_DIR)
+def _repo_dir(repo_full: str) -> str:
+    return os.path.join(REPOS_DIR, repo_full.split('/')[-1])
+
+os.makedirs(REPOS_DIR, exist_ok=True)
 for repo in REPO_LIST:
     print(f"Processing {repo}...")
-    repo_path = repo.split('/')[-1]
-    if not os.path.isdir(repo_path):
-        subprocess.run(["git", "clone", f"https://github.com/{repo}"], check=True)
-    os.chdir(repo_path)
-    subprocess.run(["git", "fetch", "--all"], check=True)
-    subprocess.run(["git", "pull"], check=True)
-    log_cmd = ["git", "log", "--use-mailmap", GIT_LOG_SINCE, GIT_LOG_FORMAT_1]
-    res = subprocess.run(log_cmd, capture_output=True, text=True, encoding="utf-8", errors="replace")
-    os.chdir("..")
+    repo_dir = _repo_dir(repo)
+    if not os.path.isdir(repo_dir):
+        subprocess.run(["git", "clone", f"https://github.com/{repo}", repo_dir], check=True)
+    else:
+        subprocess.run(["git", "-C", repo_dir, "pull"], check=True)
+    res = subprocess.run(
+        ["git", "-C", repo_dir, "log", "--use-mailmap", GIT_LOG_SINCE, GIT_LOG_FORMAT_1],
+        capture_output=True, text=True, encoding="utf-8", errors="replace")
     if res.returncode != 0:
-        print("DEBUG git log failed; stderr:", res.stderr.strip())
+        print("git log failed; stderr:", res.stderr.strip())
         sys.exit(1)
     process_log_into_aggregate(res.stdout, repo)
 
@@ -259,10 +259,9 @@ def resolve_github_via_commit(email: str, repos: list[str]) -> str | None:
     if not email:
         return None
     for r in repos:
-        repo_path = r.split('/')[-1]
-        # Find a representative commit authored by this email
-        res = subprocess.run(["git", "log", GIT_LOG_SINCE, f"--author={email}", "--format=%H", "-n", "1"],
-                           cwd=repo_path, capture_output=True, text=True, encoding="utf-8")
+        res = subprocess.run(
+            ["git", "-C", _repo_dir(r), "log", GIT_LOG_SINCE, f"--author={email}", "--format=%H", "-n", "1"],
+            capture_output=True, text=True, encoding="utf-8")
         if res.returncode != 0:
             continue
         commit_hash = (res.stdout or "").strip()
@@ -281,9 +280,9 @@ def resolve_github_via_commit(email: str, repos: list[str]) -> str | None:
 def find_coauthor_commit(name: str, email: str, repos: list[str]) -> str:
     targets = {t for t in (name.lower(), email.lower()) if t}
     for r in repos:
-        repo_path = r.split('/')[-1]
-        res = subprocess.run(["git", "log", GIT_LOG_SINCE, GIT_LOG_FORMAT_2],
-                             cwd=repo_path, capture_output=True, text=True, encoding="utf-8")
+        res = subprocess.run(
+            ["git", "-C", _repo_dir(r), "log", GIT_LOG_SINCE, GIT_LOG_FORMAT_2],
+            capture_output=True, text=True, encoding="utf-8")
         if res.returncode != 0:
             continue
         for line in res.stdout.splitlines():

--- a/etc/update-contributors.py
+++ b/etc/update-contributors.py
@@ -127,10 +127,10 @@ def process_log_into_aggregate(res: str, repo: str) -> None:
         line = raw.strip()
         if not line: continue
 
-        if line.lower().startswith("co-authored-by:"):
+        if line.casefold().startswith("co-authored-by:"):
             line = line.split(":", 1)[1].strip()
 
-        low = line.lower()
+        low = line.casefold()
         if any(b in low for b in BOT_TOKENS):
             continue
         if "[bot]" in low:
@@ -149,7 +149,7 @@ def process_log_into_aggregate(res: str, repo: str) -> None:
 
         owner = email_owner.get(email.casefold()) or name_owner.get(_norm_name(name))
         known_github = owner.get("github") if owner else None
-        key = ("gh", known_github.lower()) if known_github else ("email", ((owner and owner.get("email")) or email).casefold())
+        key = ("gh", known_github.casefold()) if known_github else ("email", ((owner and owner.get("email")) or email).casefold())
 
         rec = aggregate.get(key)
         if rec is None:
@@ -202,11 +202,11 @@ def find_author_github_nick(email: str, repos: list[str]) -> str | None:
     return None
 
 def find_coauthor_commit(name: str, email: str, repos: list[str]) -> str:
-    targets = {t for t in (name.lower(), email.lower()) if t}
+    targets = {t for t in (name.casefold(), email.casefold()) if t}
     for r in repos:
         out = git_out(_repo_dir(r), "log", GIT_LOG_SINCE, GIT_LOG_FORMAT_2)
         for line in out.splitlines():
-            low = line.lower()
+            low = line.casefold()
             if not any(t in low for t in targets):
                 continue
             m = HASH_RE.search(line)


### PR DESCRIPTION
The next level contributor script:
* Logic mostly as before.
* Key change 1: Treat coauthors the same way as authors. In particular, no separate record/report in summary.
* Key change 2: We recently decided that the people_list.yml need not be sooo human readable. As such, no point in having empty lines separate records. Have thus also dropped the old dumper.

Other than that, a massive refactor. Hopefully the script is now safer to execute, catches the coauthors correctly, easier to maintain and to read.

The result of its execution can be seen here: https://github.com/oscar-system/oscar-website/actions/runs/19005559056/job/54278479324?pr=661

Specifically, it finds:

> This PR updates the contributors list based on the latest changes.
  New contributors : 4 | ['Anna Hofer', 'Fabian Lenzen', 'StardustMath', 'Erroxe']
  Newly retired contributors : 0 | []
  Summary Notes:
> - Skipping non-address line in oscar-system/Oscar.jl: 'Benjamin Lorenz'

All of those four are coauthors. Once you run the script locally (or after merging and letting the bot run it), you will see that the script found one valid commit hash for each.

(I just notice that I dropped the "revived authors" comment, i.e. it no longer says "author x was revived". If I recall correctly there is exactly one such person as of recent. This can of course and should be added back in...)

cc @aaruni96 