### PR TITLE
Spell out month names fully (so August instead of Aug)

### DIFF
--- a/credits/contributors.md
+++ b/credits/contributors.md
@@ -31,7 +31,7 @@ page.
 </ul>
 
 ## Current Code Contributors
-These {{ site.data.people_list | where: "status", "active" | size }} individuals have contributed source code to the OSCAR project in the past 12 months (as of {{ 'now' | date: "%d %b %Y" }}).
+These {{ site.data.people_list | where: "status", "active" | size }} individuals have contributed source code to the OSCAR project in the past 12 months (as of {{ 'now' | date: "%d %B %Y" }}).
 
 <ul>
 {% for p in site.data.people_list %}
@@ -67,7 +67,7 @@ These {{ site.data.people_list | where: "status", "active" | size }} individuals
 
 ## Former Code Contributors
 
-The following {{ site.data.people_list | where: "status", "retired" | size }} individuals contributed to the OSCAR project in the past but have not in the last 12 months (as of {{ 'now' | date: "%d %b %Y" }}).
+The following {{ site.data.people_list | where: "status", "retired" | size }} individuals contributed to the OSCAR project in the past but have not in the last 12 months (as of {{ 'now' | date: "%d %B %Y" }}).
 
 <ul>
 {% for p in site.data.people_list %}

--- a/index.md
+++ b/index.md
@@ -21,7 +21,7 @@ Discover more about our project and vision on our [About]({{site.baseurl}}/about
   {% if event.end-date >= today %}
     {% assign has_upcoming_events = true %}
     {% if event.website %}
-* [{{ event.title }} ({{ event.location }}, {{ event.start-date | date: "%d %b %Y" }} to {{ event.end-date | date: "%d %b %Y" }})]({{ event.website | replace: "https://www.oscar-system.org", site.baseurl }})
+* [{{ event.title }} ({{ event.location }}, {{ event.start-date | date: "%d %B %Y" }} to {{ event.end-date | date: "%d %B %Y" }})]({{ event.website | replace: "https://www.oscar-system.org", site.baseurl }})
     {% else %}
 * {{ event.title }} ({{ event.location }}, {{ event.start-date }} to {{ event.end-date }})
     {% endif %}


### PR DESCRIPTION
Using names like Aug or Jul for months is maybe OK for
long time programmers, but I think for most "normal"
people it looks strange.
