### PR TITLE
CI: fix typo, comment; adapt to API changes

### DIFF
--- a/.github/workflows/latest_release.yml
+++ b/.github/workflows/latest_release.yml
@@ -26,7 +26,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install PyGithub pyyaml requests
 
-      - name: Run Tutorial Status Script
+      - name: Fetch latest OSCAR release
         env:
           API_KEY: ${{ secrets.API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/etc/update-latest-release.py
+++ b/etc/update-latest-release.py
@@ -30,7 +30,7 @@ except Exception as e:
     exit()
 
 dt = release.created_at
-version = release.title[1:]
+version = release.name[1:]
 
 releasestring = f"version: '{version}'\nyear: '{dt.year}'\nmonth: '{dt.month}'\nday: '{dt.day}'\ndate: {dt.date()}\n"
 


### PR DESCRIPTION
Using release.title still works but results in a deprecation warning
