### PR TITLE
Update contributors

### DIFF
--- a/_data/people_list.yml
+++ b/_data/people_list.yml
@@ -455,7 +455,10 @@
   status: retired
   repos: []
 - name: Fabian Lenzen
+  affiliation: TU Berlin
   email: fabian.lenzen@tu-berlin.de
+  github: flenzen
+  website: https://page.math.tu-berlin.de/~lenzen/
   status: active
   comment: Co-author of commit fbc743b6a976c2338c4a09f647088e29791b2cbd
   repos:

--- a/_data/people_list.yml
+++ b/_data/people_list.yml
@@ -196,8 +196,11 @@
   status: retired
   comment: PhD Student of Mathias Schulze until ~2021.
   repos: []
-- name: Erroxe
-  email: you@example.com
+- name: Erroxe Etxabarri Alberdi
+  affiliation: Mondragon Unibertsitatea
+  email: eetxabarri@mondragon.edu
+  github: Erroxe
+  website: https://sites.google.com/view/erroxe-etxabarri-alberdi/home
   status: active
   comment: Co-author of commit 6b2cef5a53b095f3998ba3444cf192ce4fadf797
   repos:

--- a/_data/people_list.yml
+++ b/_data/people_list.yml
@@ -765,8 +765,11 @@
   website: https://www.math.uni-tuebingen.de/de/forschung/algebra/personen/justus-springer
   status: retired
   repos: []
-- name: StardustMath
-  email: zh112028@gmail.com
+- name: Jinghao Chen
+  affiliation: University of Science and Technology of China
+  email: chenjinghao@mail.ustc.edu.cn
+  github: StardustMath
+  website: https://stardust-math.github.io/
   status: active
   comment: Co-author of commit 6b2cef5a53b095f3998ba3444cf192ce4fadf797
   repos:


### PR DESCRIPTION
@flenzen @Erroxe @Stardust-math

This PR updates the contributor information for the OSCAR website based on your contributions to the project.

Please take a moment to review the details (name, affiliation, links, etc.). If anything is incorrect or you would prefer different information to be shown (including using only your GitHub handle), just let me know (e.g. via slack) and I will adjust it accordingly.

Closes https://github.com/oscar-system/oscar-website/issues/680.