### PR TITLE
Activate release checklist with only a single day "delay"

### DIFF
--- a/.github/workflows/release-checklist.yml
+++ b/.github/workflows/release-checklist.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           API_KEY: ${{ secrets.GITHUB_TOKEN }}
           TARGET_REPO: oscar-system/Oscar.jl
-          RECENCY_DAYS: "999"
+          RECENCY_DAYS: "1"
           ISSUE_PREFIX: "OSCAR"
           ISSUE_LABELS: "release-process"
         run: |


### PR DESCRIPTION
Once merged, I will close https://github.com/oscar-system/oscar-website/issues/679. After the change in this PR this issue should remain closed.

The next step will be to watch the behavior of this action in regards to the upcoming Oscar 1.6.0 release. Ideally, this action should open an issue once 1.6.0 has been released (and thereby remind us to spread the word of the new release on the mailing list). Also, once we then close said issue (after the release has been out for more than a single day), the action should not reopen the issue. To be tested...

This PR prepares all of these tests.

cc @aaruni96 @fingolfin 