### PR TITLE
Restore albatross-2026 title

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -45,7 +45,7 @@
   website: https://mathconf.eu/adtg-2026/
   satellite: "Yes"
 
-- title: albatross-2026
+- title: "albatross-2026: ALgeBrAic meThods foR pOlynomial System Solving 2026"
   start-date: "2026-09-01"
   end-date: "2026-09-04"
   location: Sorbonne University, Paris, France


### PR DESCRIPTION
To use colons in even titles, put the title in quotation
marks. I would in fact recommend always doing that, to
prevent other fun YAML features from causing unexpected
surprises.
