### PR TITLE
Switch to new mailing list

### DIFF
--- a/.github/release-checklist-template.md
+++ b/.github/release-checklist-template.md
@@ -8,7 +8,7 @@ labels: release-process
 
 A new OSCAR release **v{{ env.VERSION }}** was published on **{{ env.PUBLISHED_UTC }}** (UTC)
 
-Please send an email to the OSCAR mailing list (<oscar-dev@mathematik.uni-kl.de>) to inform about
+Please send an email to the OSCAR mailing list (<devel@oscar-system.org>) to inform about
 this update. You can use the following template:
 
 

--- a/contact-and-support.md
+++ b/contact-and-support.md
@@ -28,4 +28,4 @@ For public and permanent discussions, use our [GitHub discussion forum](https://
 
 * Newsletter: To receive updates about OSCAR, including new releases and important announcements, subscribe to our [newsletter](https://oscar-system.org/newsletter). This is a low-traffic mailing list. You can also look at [its archive](https://lists.uni-kl.de/oscar/arc/news) to see past issues.
 
-* OSCAR events -- and seldomly technical developments -- are announced via a low-traffic mailing list `oscar-dev`. To join this mailing list, visit <https://mail.mathematik.uni-kl.de/mailman/listinfo/oscar-dev> and follow the instructions there.
+* OSCAR events -- and seldomly technical developments -- are announced via a low-traffic mailing list `devel@oscar-system.org`. To join this mailing list, visit <https://oscar-system.org/lists/devel> and follow the instructions there.


### PR DESCRIPTION
I plan to announce the new lists shortly, and then this PR should be merged soon-ish.

Note that it currently only mentions <devel@oscar-system.org> but not <users@oscar-system.org>. Which makes sense in so far as that the latter has had basically no traffic in the last few years, and we sent all announcements etc. to the former; but only a few to the latter. We may wish to change that in the future, or not (depending also on how successful we are in general... and what other communication platforms we can make available...)

Anyway, subscriptions for the two lists can be managed via

  https://oscar-system.org/lists/devel

and

  https://oscar-system.org/lists/users

These are redirects to the real sites (which right now are at uni-kl.de but will probably migrate this year to rptu.de domains...)