### PR TITLE
Fix and update CI

### DIFF
--- a/.github/workflows/test-contributer-script.yml
+++ b/.github/workflows/test-contributer-script.yml
@@ -67,28 +67,27 @@ jobs:
         cat _data/people_list.yml
         echo "::endgroup::"
 
-    - name: Validate overall structure of _data/people_list.yml
-      run:
-        yq -e '
-          type == "!!seq" and length > 0
-          and
-          (
-            map(
+    - name: Validate overall structure of _data/people_list.yml (print offenders)
+      run: |
+        yq -e 'type == "!!seq" and length > 0' _data/people_list.yml >/dev/null
+        yq -r '
+          to_entries
+          | map(
               select(
-                (type != "!!map")
-                or (has("name")   | not) or (.name   | type != "!!str" or length == 0)
-                or (has("status") | not) or (.status | type != "!!str" or length == 0)
-                or (has("github") | not) or (.github | type != "!!str" or length == 0)
+                (.value | type != "!!map")
+                or (.value.name?   | type != "!!str" or length == 0)
+                or (.value.status? | type != "!!str" or length == 0)
               )
             )
-            | length == 0
-          )
-        ' _data/people_list.yml
+        ' _data/people_list.yml | tee /tmp/offenders.json
+        test "$(cat /tmp/offenders.json)" = "[]"
 
     - name: Validate GitHub handles of contributors (in _data/people_list.yml) are unique
-      run:
+      run: |
         yq -e '
-          (map(.github) | length) == (map(.github) | unique | length)
+          (map(.github? // "") | map(select(length > 0)) | length)
+          ==
+          (map(.github? // "") | map(select(length > 0)) | unique | length)
         ' _data/people_list.yml
 
     - name: Ensure that the number of contributors (in _data/people_list.yml) did not shrink


### PR DESCRIPTION
1. Not every entry in `_data/people_list.yml` has a github entry; we cannot determine these automatically for coauthors. Still, the CI tests assume so. This requires some changes.
2. For simpler debugging, print any entry in `_data/people_list.yml` that violates our criteria. This should help to debug in the future.

Cf. https://github.com/oscar-system/oscar-website/issues/753