### PR TITLE
Attempt towards a markdown checker workflow

### DIFF
--- a/.github/workflows/markdownchecks.yml
+++ b/.github/workflows/markdownchecks.yml
@@ -26,4 +26,6 @@ jobs:
             !.github/**
             !etc/**
             !README.hyde.md
+            !LICENSE.hyde.md
+            !README.md
             !_sass/hyde.scss

--- a/.github/workflows/markdownchecks.yml
+++ b/.github/workflows/markdownchecks.yml
@@ -25,7 +25,7 @@ jobs:
             !_site/**
             !.github/**
             !etc/**
-            !README.hyde.md
+            !README*
             !LICENSE.hyde.md
             !README.md
             !_sass/hyde.scss

--- a/.github/workflows/markdownchecks.yml
+++ b/.github/workflows/markdownchecks.yml
@@ -1,0 +1,29 @@
+name: Markdown checks
+
+on:
+  pull_request:
+  push:
+    branches: [gh-pages]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  markdownchecks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Lint Markdown
+        uses: DavidAnson/markdownlint-cli2-action@v22
+        with:
+          globs: |
+            **/*.md
+            !vendor/**
+            !_site/**
+            !.github/**
+            !etc/**
+            !README.hyde.md
+            !_sass/hyde.scss

--- a/.github/workflows/markdownchecks.yml
+++ b/.github/workflows/markdownchecks.yml
@@ -21,11 +21,8 @@ jobs:
         with:
           globs: |
             **/*.md
-            !vendor/**
             !_site/**
             !.github/**
             !etc/**
             !README*
             !LICENSE.hyde.md
-            !README.md
-            !_sass/hyde.scss

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,31 @@
+# Markdown rules for CI
+#
+# We intentionally enable only a small set of rules that catch
+# likely mistakes or readability issues, not stylistic preferences.
+#
+# Rule documentation:
+#   https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+#
+config:
+  # Start from a clean slate: no rules enabled unless explicitly listed
+  default: false
+
+  # MD009 — no trailing spaces at end of lines
+  # (allows exactly two spaces for an intentional Markdown line break)
+  MD009:
+    br_spaces: 2
+    strict: false
+
+  # MD010 — disallow hard tabs (can render inconsistently)
+  MD010: true
+
+  # MD040 — fenced code blocks should specify a language
+  # (improves readability and syntax highlighting)
+  MD040: true
+
+  # MD047 — files should end with a single newline character
+  # (POSIX text file convention; avoids diff noise)
+  MD047: true
+
+  # Optional / currently disabled:
+  # MD031 — fenced code blocks should be surrounded by blank lines

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -29,3 +29,4 @@ config:
 
   # Optional / currently disabled:
   # MD031 — fenced code blocks should be surrounded by blank lines
+  MD031: true


### PR DESCRIPTION
This PR is a first step towards https://github.com/oscar-system/oscar-website/issues/514 by introducing automated Markdown checks. The idea is to create a minimal and non-disruptive starting point; the exact scope and strictness of Markdown checks can be refined further based on discussion. Right now, we do **not** enforce a strict Markdown style (yet), but focus on catching a small set of common and potentially problematic issues, such as missing language tags on fenced code blocks, trailing whitespace, missing final newlines.

A few comments/questions:
- Running `markdownlint` with its default configuration results in about 1800 errors. I restricted the configuration to a small set of rules that focus on correctness rather than style, cf. `.markdownlint-cli2.yaml`
- While fixing the remaining markdown errors, it became apparent that `README.md` seems (at least partially) outdated.  Maybe it is worth to explain the current workflows/tutorial tester practices there?
- Currently, `README.md` **is included** in the Markdown checks. However, this file is (to my knowledge) not rendered as part of the OSCAR website, but it *is* the main entry point for visitors to this GitHub repository. I am undecided whether it should be excluded from the markdown checks or not. Ideas?
- Similarly, a fenced code block without a language specification was found in `README.hyde.md`. I fixed it. However, I am undecided if this should be included in our test.