### PR TITLE
Migrate hosting to newer server

### DIFF
--- a/etc/README.server.md
+++ b/etc/README.server.md
@@ -3,19 +3,11 @@
 This document describes how the OSCAR website hosting is set up, to help
 people who need to troubleshoot it or migrate it to a new host.
 
-## Required software on the server
-
-To ensure the required software is installed on the server, run this
-(assuming a Debian or Ubuntu based environment):
-
-    apt install git bundler python3
-
-
-## Where it is
+## Where it is hosted
 
 The server can be reached via SSH:
 
-    ssh www-mathe-oscar@www-admin11.uni-kl.de
+    ssh www-mathe-oscar@www-admin13.rz.rptu.de
 
 The website is update from a git clone of the website repository at
 
@@ -103,10 +95,10 @@ following as root:
 ### Requirements
 
 - Ubuntu or Debian VM
+- Python 3 with pip (`apt install python3 python3-pip`)
 - Apache 2 (`apt install apache2`)
 - Ruby 2.7 or newer, including development headers, and bundler (`apt-get install bundler`)
 - PHP (only for the webhook) (`apt install libapache2-mod-php ; a2enmod php7.4`)
-- Jekyll (installed via `gem` and `bundler`, see below)
 
 
 ## Further steps as `root`

--- a/etc/README.server.md
+++ b/etc/README.server.md
@@ -11,12 +11,12 @@ The server can be reached via SSH:
 
 The website is update from a git clone of the website repository at
 
-    /srv/www/www-mathe-oscar/data/oscar-website
+    ~/data/oscar-website
 
 This clone is owned by user `www-mathe-oscar` and group `www-mathe-oscar`. If anything goes
 wrong with these permissions, they can be fixed via
 
-    chown -R www-mathe-oscar:www-mathe-oscar /srv/www/www-mathe-oscar/data/oscar-website
+    chown -R www-mathe-oscar:www-mathe-oscar ~/data/oscar-website
 
 ## Automatic updates via webhook
 
@@ -25,7 +25,7 @@ repository, GitHub activates a webhook we provide via `webhook.php` at
 <https://www.oscar-system.org/webhook.php>.
 
 The crucial bit is at the end of this .php file, where an empty file
-`/srv/www/www-mathe-oscar/data/oscar-website.trigger` is created. This is detected by a
+`~/data/oscar-website.trigger` is created. This is detected by a
 systemd unit `~/.config/systemd/user/oscar-website.path` (a copy of this file is
 in the `etc` directory of the website repository).
 
@@ -35,7 +35,7 @@ This then triggers `~/.config/systemd/user/oscar-website.service`
 This finally executes `etc/update.sh`, which runs jekyll.
 
 
-For authentication, we set a secret token in `/srv/www/www-mathe-oscar/data/webhook.secret`
+For authentication, we set a secret token in `~/data/webhook.secret`
 which looks like this:
 
     SetEnv GITHUB_WEBHOOK_SECRET "MY_SECRET"
@@ -70,7 +70,7 @@ This prints a log with extra info. However, it might also say "service not
 found". In that case, make sure that `oscar-website.service` and
 `oscar-website.path` are installed and enabled:
 
-    cp /srv/www/www-mathe-oscar/data/oscar-website/etc/oscar-website.* ~/.config/systemd/user
+    cp ~/data/oscar-website/etc/oscar-website.* ~/.config/systemd/user
     systemctl --user enable oscar-website.service oscar-website.path
 
 Also helpful is to study the log for the relevant systemd units
@@ -82,12 +82,12 @@ clone) are broken file permissions which can impede further operations, such
 as git pulling updates or jekyll updating the website. To fix these, run the
 following as root:
 
-    chown -R www-mathe-oscar:www-mathe-oscar /srv/www/www-mathe-oscar/data/oscar-website
-    chown -R www-mathe-oscar:www-mathe-oscar /srv/www/www-mathe-oscar/data/http
+    chown -R www-mathe-oscar:www-mathe-oscar ~/data/oscar-website
+    chown -R www-mathe-oscar:www-mathe-oscar ~/data/http
 
-    touch /srv/www/www-mathe-oscar/data/oscar-website.trigger
-    chown www-mathe-oscar:www-mathe-oscar /srv/www/www-mathe-oscar/data/oscar-website.trigger
-    chmod 0664 /srv/www/www-mathe-oscar/data/oscar-website.trigger
+    touch ~/data/oscar-website.trigger
+    chown www-mathe-oscar:www-mathe-oscar ~/data/oscar-website.trigger
+    chmod 0664 ~/data/oscar-website.trigger
 
 
 ## Initial setup / what if the server VM is upgraded
@@ -105,10 +105,10 @@ following as root:
 
 1. Set up a user `www-mathe-oscar` in group `www-mathe-oscar`
 
-2. Set up an Apache2 site with data in `/srv/www/www-mathe-oscar/data/http/` (or modify the units
+2. Set up an Apache2 site with data in `~/data/http/` (or modify the units
    here for alternate locations); ensure `www-mathe-oscar` owns it, i.e.
 
-        chown -R www-mathe-oscar:www-mathe-oscar /srv/www/www-mathe-oscar/data/http
+        chown -R www-mathe-oscar:www-mathe-oscar ~/data/http
 
    In the config for that site, make sure to set `GITHUB_WEBHOOK_SECRET` as described
    elsewhere in this file, and enable PHP.
@@ -122,17 +122,23 @@ following as root:
 
 As `www-mathe-oscar:www-mathe-oscar`  (`sudo -u www-mathe-oscar -g www-mathe-oscar bash`):
 
-In the `www-mathe-oscar` home directory add a clone of the `oscar-website` git repository, i.e.,
-in `/srv/www/www-mathe-oscar/data/oscar-website` (otherwise adjust `oscar-website.service`). Also do
+In the `www-mathe-oscar` home directory add symlinks pointing to the web
+server directories:
 
-    touch /srv/www/www-mathe-oscar/data/oscar-website.trigger
-    chown www-mathe-oscar:www-mathe-oscar /srv/www/www-mathe-oscar/data/oscar-website.trigger
-    chmod 0644 /srv/www/www-mathe-oscar/data/oscar-website.trigger
+        ln -s /srv/www/www-mathe-oscar/data ~/data
+        ln -s /srv/www/www-mathe-oscar/data/http ~/data/http
+
+Then clone the `oscar-website` git repository inside the data directory, i.e.,
+as `~/data/oscar-website` (otherwise adjust `oscar-website.service`). Also do
+
+    touch ~/data/oscar-website.trigger
+    chown www-mathe-oscar:www-mathe-oscar ~/data/oscar-website.trigger
+    chmod 0644 ~/data/oscar-website.trigger
 
 Next install and activate the systemd units:
 
     mkdir -p ~/.config/systemd/user/
-    cp /srv/www/www-mathe-oscar/data/oscar-website/etc/oscar-website.* ~/.config/systemd/user/
+    cp ~/data/oscar-website/etc/oscar-website.* ~/.config/systemd/user/
     systemctl --user enable oscar-website.service oscar-website.path
     systemctl --user start oscar-website.service oscar-website.path
 

--- a/etc/update.sh
+++ b/etc/update.sh
@@ -2,13 +2,13 @@
 set -ex
 
 # fetch latest changes
-cd /srv/www/www-mathe-oscar/data/oscar-website/
+cd ~/data/oscar-website/
 git fetch --all --prune
 git checkout --force gh-pages
 git reset --hard origin/gh-pages
 
 # add webhook secret
-cat /srv/www/www-mathe-oscar/data/webhook.secret >> .htaccess
+cat ~/data/webhook.secret >> .htaccess
 
 # install gems
 bundle config set --local path 'vendor/bundle'
@@ -33,4 +33,4 @@ python3 -m pip install --upgrade -r etc/requirements.txt
 ./etc/update-dates.py || :
 
 # run jekyll
-bundle exec jekyll build --config _config.yml,_config_production.yml -d /srv/www/www-mathe-oscar/data/http
+bundle exec jekyll build --config _config.yml,_config_production.yml -d ~/data/http


### PR DESCRIPTION
Our university will ask everyone to migrate to a new hosting environment and will decomission the old one. Let's stay ahead of the curve and migrate now (the 'new' server has already been in use for quite some time anyway, so it is already well-tested).

This updates our internal documentation to provide the new server hostname for SSH access. Also update some of our instructions as to what software is required (we now rely on pip, so it must be installed).