### PR TITLE
Ak96/debug release check

### DIFF
--- a/.github/workflows/release-checklist.yml
+++ b/.github/workflows/release-checklist.yml
@@ -61,6 +61,7 @@ jobs:
         id: release
         run: |
           set -xuo pipefail
+          set +e
 
           git diff --quiet HEAD -- _data/release.yml
           ec=$?

--- a/.github/workflows/release-checklist.yml
+++ b/.github/workflows/release-checklist.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Determine whether _data/release.yml changed
         id: release
         run: |
-          set -uo pipefail
+          set -xuo pipefail
 
           git diff --quiet HEAD -- _data/release.yml
           ec=$?


### PR DESCRIPTION
Manually setting `+e` appears to be a requirement. (I thought that's the default, perhaps I'm mistaken).

Adding `-x` also seems like a good idea, because it causes the script to print the command its going to execute before it executes it, and thus helps in debugging if/when it fails.

