### PR TITLE
Add link to OSCAR merch

### DIFF
--- a/about.md
+++ b/about.md
@@ -174,6 +174,8 @@ algebraic solving.
 
 🤖 **[Contributing Guide]({{site.baseurl}}/contributing/)** – Learn how to contribute code, documentation, or ideas.
 
+🧮 **[OSCAR Merchandise](https://oscar-system.myspreadshop.de/)** – OSCAR-branded items to support and represent the project.
+
 🤝 **[Contact & Support]({{site.baseurl}}/contact-and-support/)** – Find ways to connect, ask questions, or get help.
 
 🏛️ **Funding** – OSCAR is supported by the [German Research Foundation (DFG)](https://www.dfg.de/en) through the [Collaborative Research Center TRR 195](https://www.computeralgebra.de/sfb/)."


### PR DESCRIPTION
Closes https://github.com/oscar-system/oscar-website/issues/701.

One of many possibilities; add this link to the footer (bottom left), e.g. as follows ("Merchandise" - third from the bottom):

<img width="198" height="163" alt="Screenshot_20260216_142503" src="https://github.com/user-attachments/assets/3171f275-75d4-4b0e-ad6d-03c9c1efafbc" />