### PR TITLE
Additional date format adjustment and wording changes in release checklist template

### DIFF
--- a/.github/release-checklist-template.md
+++ b/.github/release-checklist-template.md
@@ -25,7 +25,10 @@ Major releases (1.x.0) should also be announced to the SFB mailing lists (like <
 > Highlights of this release:
 > - (Add 2-3 bullet points summarizing major changes or improvements)
 > 
-> The new version is available from GitHub and via the usual installation methods. Full release notes can be found at https://github.com/oscar-system/Oscar.jl/releases/tag/v{{ env.VERSION }}
+> The new version is available from GitHub and via the usual installation methods
+> (cf. https://www.oscar-system.org/install/ and https://www.oscar-system.org/upgrade/).
+> 
+> The release notes can be found at https://github.com/oscar-system/Oscar.jl/releases/tag/v{{ env.VERSION }}
 >
 > Best regards,
 > The OSCAR Team

--- a/.github/workflows/release-checklist.yml
+++ b/.github/workflows/release-checklist.yml
@@ -79,7 +79,7 @@ jobs:
           version="$(yq -r '.version' _data/release.yml)"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           published="$(yq -r '.date' _data/release.yml)"
-          published="$(date -d "$published" '+%-d %b %Y')"
+          published="$(date -d "$published" '+%d %b %Y')"
           echo "published=$published" >> "$GITHUB_OUTPUT"
 
       - name: Debug changed/version and diff

--- a/.github/workflows/release-checklist.yml
+++ b/.github/workflows/release-checklist.yml
@@ -79,6 +79,7 @@ jobs:
           version="$(yq -r '.version' _data/release.yml)"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           published="$(yq -r '.date' _data/release.yml)"
+          published="$(date -d "$published" '+%-d %b %Y')"
           echo "published=$published" >> "$GITHUB_OUTPUT"
 
       - name: Debug changed/version and diff
@@ -89,6 +90,7 @@ jobs:
           echo "sha:                    ${{ github.sha }}"
           echo "new release?:           ${{ steps.release.outputs.changed }}"
           echo "latest OSCAR version:   ${{ steps.release.outputs.version }}"
+          echo "latest OSCAR published: ${{ steps.release.outputs.published }}"
 
           echo ""
           echo "== git status =="


### PR DESCRIPTION
This PR formats the github variable `published` in the release checklist workflow, so that in the release checklist issue, the date is formatted as uniformly applied across the website. As such, the email send out to inform about the latest release will employ the same date format as employed on the website.

I added a printout in the release checklist workflow to verify that the date has been formatted correctly, see https://github.com/oscar-system/oscar-website/actions/runs/26087062488/job/76702741539?pr=841 line 43.