### PR TITLE
Add zenodo context DOI (no version) to OSCAR bib entry

### DIFF
--- a/credits/Citing-OSCAR.md
+++ b/credits/Citing-OSCAR.md
@@ -27,6 +27,7 @@ If you are using **BibTeX**, you can use the following BibTeX entries:
   title        = {O{SCAR} -- {O}pen {S}ource {C}omputer {A}lgebra {R}esearch system, {V}ersion {{ site.data.release.version }}},
   year         = { {{- site.data.release.year }}},
   url          = {https://www.oscar-system.org},
+  doi          = {10.5281/zenodo.12077975}
 }
 
 @book{OSCAR-book,


### PR DESCRIPTION
Unless I am mistaken, this closes https://github.com/oscar-system/Oscar.jl/issues/5219.

Note that the README.md in Oscar.jl refers to the Oscar website, hence no change to this README file is needed.